### PR TITLE
Automatically open the mobilepay app

### DIFF
--- a/KronorComponents/Common/EmbeddedPaymentStatechart.swift
+++ b/KronorComponents/Common/EmbeddedPaymentStatechart.swift
@@ -91,6 +91,13 @@ final class EmbeddedPaymentStatechart : StateMachineBuilder {
                 on(.cancel) {
                     transition(to: .paymentRejected, emit: .cancelAndNotifyFailure)
                 }
+                // In case the session was completed while trying to cancel
+                on(.paymentAuthorized) {
+                    transition(to: .paymentCompleted, emit: .notifyPaymentSuccess)
+                }
+                on(.paymentRejected) {
+                    transition(to: .paymentRejected)
+                }
             }
 
             state(.paymentRequestInitialized) {

--- a/KronorComponents/Common/EmbeddedPaymentView.swift
+++ b/KronorComponents/Common/EmbeddedPaymentView.swift
@@ -40,7 +40,11 @@ struct EmbeddedPaymentView: View {
         self.innerBody
             .onOpenURL(perform: { url in
                 Task {
-                    if url.absoluteString.hasPrefix(self.viewModel.returnURL.absoluteString) {
+                    let components = URLComponents(string: url.absoluteString)
+                    let isCancel = components?.queryItems?.contains{ item in
+                        item.name == "cancel"
+                    }
+                    if isCancel ?? false {
                         await self.viewModel.transition(.waitForCancel)
                     }
                 }

--- a/KronorComponents/Common/EmbeddedPaymentView.swift
+++ b/KronorComponents/Common/EmbeddedPaymentView.swift
@@ -17,8 +17,15 @@ struct EmbeddedPaymentView: View {
     func dismissSheet() {
         Task {
             if self.viewModel.state != .paymentCompleted && self.viewModel.state != .paymentRejected {
+                await self.viewModel.transition(.waitForCancel)
+            }
+        }
+    }
+
+    func cancelNow() {
+        Task {
+            if self.viewModel.state != .paymentCompleted && self.viewModel.state != .paymentRejected {
                 await self.viewModel.transition(.cancel)
-                self.webView.link = URL(string: "https://kronor.io")!
             }
         }
     }
@@ -30,6 +37,17 @@ struct EmbeddedPaymentView: View {
     }
 
     var body: some View {
+        self.innerBody
+            .onOpenURL(perform: { url in
+                Task {
+                    if url.absoluteString.hasPrefix(self.viewModel.returnURL.absoluteString) {
+                        await self.viewModel.transition(.waitForCancel)
+                    }
+                }
+            })
+    }
+
+    var innerBody: some View {
         switch viewModel.state {
         
         case .initializing, .creatingPaymentRequest, .waitingForPaymentRequest:
@@ -43,8 +61,7 @@ struct EmbeddedPaymentView: View {
                      return false
                     }
 
-                    let kronorHost = self.webView.link.host?.hasSuffix("kronor.io") ?? false
-                    return kronorHost && self.webView.link != self.viewModel.returnURL
+                    return self.webView.link != self.viewModel.returnURL
                 },
                 set: { _ in }
             )
@@ -55,7 +72,7 @@ struct EmbeddedPaymentView: View {
                         EmbeddedSiteView(
                             webViewModel: self.webView,
                             url: url,
-                            onCancel: dismissSheet
+                            onCancel: cancelNow
                         )
                     }
                 }.transition(.slide))

--- a/KronorComponents/Common/EmbeddedPaymentViewModel.swift
+++ b/KronorComponents/Common/EmbeddedPaymentViewModel.swift
@@ -207,7 +207,7 @@ class EmbeddedPaymentViewModel: ObservableObject {
             }
 
         case .cancelAfterDeadline:
-            DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
                 Task { [weak self] in
                     if let state = self?.state, state == .waitingForPaymentRequest {
                         Self.logger.info("attempting to cancel payment after deadline")

--- a/KronorComponents/Common/EmbeddedPaymentViewModel.swift
+++ b/KronorComponents/Common/EmbeddedPaymentViewModel.swift
@@ -187,7 +187,7 @@ class EmbeddedPaymentViewModel: ObservableObject {
             await MainActor.run {
                 self.embeddedSiteURL = self.sessionURL
             }
-            
+
         case .resetState:
             self.subscription?.cancel()
             self.subscription = nil
@@ -204,6 +204,16 @@ class EmbeddedPaymentViewModel: ObservableObject {
 
             Task {
                 await self.transition(.initialize)
+            }
+
+        case .cancelAfterDeadline:
+            DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+                Task { [weak self] in
+                    if let state = self?.state, state == .waitingForPaymentRequest {
+                        Self.logger.info("attempting to cancel payment after deadline")
+                        await self?.transition(.cancel)
+                    }
+                }
             }
         }
     }

--- a/KronorComponents/Common/SwiftUIWebView.swift
+++ b/KronorComponents/Common/SwiftUIWebView.swift
@@ -21,7 +21,10 @@ struct SwiftUIWebView: UIViewRepresentable {
 
     func makeUIView(context: UIViewRepresentableContext<SwiftUIWebView>) -> WKWebView {
         self.webView.navigationDelegate = context.coordinator
+        self.webView.allowsBackForwardNavigationGestures = false
+        self.webView.allowsLinkPreview = false
         self.webView.load(URLRequest(url: self.url))
+
         return self.webView
     }
 
@@ -41,6 +44,26 @@ struct SwiftUIWebView: UIViewRepresentable {
                 self.viewModel.link = url
             }
             self.viewModel.didFinishLoading = true
+        }
+
+        func webView(_ webView: WKWebView,
+                     decidePolicyFor navigationAction: WKNavigationAction,
+                     decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+
+            // if the url is not http(s) schema, then the UIApplication open the url
+            if let url = navigationAction.request.url,
+               let scheme = url.scheme,
+               scheme != "http",
+               scheme != "https" {
+
+                UIApplication.shared.open(url)
+
+                // cancel the request
+                decisionHandler(.cancel)
+            } else {
+                // allow the request
+                decisionHandler(.allow)
+            }
         }
     }
 


### PR DESCRIPTION
This allows the mobilepay webpage to attempt opening the app automatically, which makes the payment flow smoother.