### PR TITLE
Resolve Existential Types Incompatibility with AnyView

### DIFF
--- a/KronorComponents/Common/EmbeddedPaymentView.swift
+++ b/KronorComponents/Common/EmbeddedPaymentView.swift
@@ -1,43 +1,25 @@
 //
 //  EmbeddedPaymentView.swift
-//  
+//
 //
 //  Created by Jose-JORO on 2023-01-18.
 //
 
 import SwiftUI
 
-struct EmbeddedPaymentView: View {
-    @ObservedObject var viewModel: EmbeddedPaymentViewModel
-
-    var waitingView: any View
+struct EmbeddedPaymentView<Content: View>: View {
+    @ObservedObject private var embeddedPayViewModel: EmbeddedPaymentViewModel
+    @ObservedObject private var webViewModel = WebViewModel()
+    @State private var keepWaitingOpen = false
+    private var waitingView: Content
     
-    @ObservedObject var webView = WebViewModel()
-    
-    func dismissSheet() {
-        Task {
-            if self.viewModel.state != .paymentCompleted && self.viewModel.state != .paymentRejected {
-                await self.viewModel.transition(.waitForCancel)
-            }
-        }
-    }
-
-    func cancelNow() {
-        Task {
-            if self.viewModel.state != .paymentCompleted && self.viewModel.state != .paymentRejected {
-                await self.viewModel.transition(.cancel)
-            }
-        }
-    }
-
-    func abortPayment() {
-        Task {
-            await self.viewModel.transition(.cancelFlow)
-        }
+    init (viewModel: EmbeddedPaymentViewModel, waitingView: Content) {
+        self.embeddedPayViewModel = viewModel
+        self.waitingView = waitingView
     }
 
     var body: some View {
-        self.innerBody
+        self.innerBody()
             .onOpenURL(perform: { url in
                 Task {
                     let components = URLComponents(string: url.absoluteString)
@@ -45,89 +27,94 @@ struct EmbeddedPaymentView: View {
                         item.name == "cancel"
                     }
                     if isCancel ?? false {
-                        await self.viewModel.transition(.waitForCancel)
+                        await self.embeddedPayViewModel.transition(.waitForCancel)
                     }
                 }
             })
     }
 
-    var innerBody: some View {
-        switch viewModel.state {
-        
+    @ViewBuilder
+    private func innerBody() -> some View {
+        switch embeddedPayViewModel.state {
         case .initializing, .creatingPaymentRequest, .waitingForPaymentRequest:
-            return AnyView(self.waitingView)
-
-
+            self.waitingView
         case .paymentRequestInitialized, .waitingForPayment:
-            let keepOpen = Binding(
-                get: {
-                    if self.viewModel.embeddedSiteURL == nil {
-                     return false
-                    }
-
-                    return self.webView.link != self.viewModel.returnURL
-                },
-                set: { _ in }
-            )
-
-            return AnyView(self.waitingView
-                .sheet(isPresented: keepOpen, onDismiss: dismissSheet) {
-                    if let url = self.viewModel.embeddedSiteURL {
+            self.waitingView
+                .transition(.slide)
+                .onReceive(embeddedPayViewModel.$embeddedSiteURL.combineLatest(webViewModel.$link)) { (embeddedSiteURL, link) in
+                        if let _ = embeddedSiteURL {
+                            keepWaitingOpen = (link != embeddedPayViewModel.returnURL)
+                        } else {
+                            keepWaitingOpen = false
+                        }
+                }
+                .sheet(isPresented: $keepWaitingOpen, onDismiss: dismissSheet) {
+                    if let url = self.embeddedPayViewModel.embeddedSiteURL {
                         EmbeddedSiteView(
-                            webViewModel: self.webView,
+                            webViewModel: self.webViewModel,
                             url: url,
                             onCancel: cancelNow
                         )
                     }
-                }.transition(.slide))
-
-
+                }
         case .paymentRejected:
-            return AnyView(
-                PaymentRejectedView(viewModel: self.viewModel)
-            )
-
-            
+            PaymentRejectedView(viewModel: self.embeddedPayViewModel)
         case .paymentCompleted:
-            return AnyView(
-                HStack {
-                    Spacer()
-                    Image(systemName: "checkmark.circle")
-                        .foregroundColor(Color.green)
-
-                    Text(
-                        "Payment completed",
-                        bundle: .module,
-                        comment:  "A success message indicating that the payment was completed and the payment session will end"
-                    )
-                    .font(.headline)
+            HStack {
+                Spacer()
+                Image(systemName: "checkmark.circle")
                     .foregroundColor(Color.green)
-
-                    Spacer()
-                }
-            )
-
-
+                
+                Text(
+                    "Payment completed",
+                    bundle: .module,
+                    comment:  "A success message indicating that the payment was completed and the payment session will end"
+                )
+                .font(.headline)
+                .foregroundColor(Color.green)
+                
+                Spacer()
+            }
         case .errored(_):
-            return AnyView(
-                HStack {
-                    Spacer()
-                    Image(systemName: "xmark.circle")
-                        .foregroundColor(Color.red)
-
-                    Text(
-                        "Could not complete the payment due to an error. Please try again after a short time",
-                        bundle: .module,
-                        comment:  "An error message indicating there was an unexpected error with the payment"
-                    )
-                    .font(.headline)
+            HStack {
+                Spacer()
+                Image(systemName: "xmark.circle")
                     .foregroundColor(Color.red)
-                    .padding(.horizontal)
+                
+                Text(
+                    "Could not complete the payment due to an error. Please try again after a short time",
+                    bundle: .module,
+                    comment:  "An error message indicating there was an unexpected error with the payment"
+                )
+                .font(.headline)
+                .foregroundColor(Color.red)
+                .padding(.horizontal)
+                
+                Spacer()
+            }
+            .padding(.all)
+        }
+    }
+    
+    private func dismissSheet() {
+        Task {
+            if self.embeddedPayViewModel.state != .paymentCompleted && self.embeddedPayViewModel.state != .paymentRejected {
+                await self.embeddedPayViewModel.transition(.waitForCancel)
+            }
+        }
+    }
 
-                    Spacer()
-                }
-                    .padding(.all)
-            )
+    private func cancelNow() {
+        Task {
+            if self.embeddedPayViewModel.state != .paymentCompleted && self.embeddedPayViewModel.state != .paymentRejected {
+                await self.embeddedPayViewModel.transition(.cancel)
+            }
+        }
+    }
+
+    private func abortPayment() {
+        Task {
+            await self.embeddedPayViewModel.transition(.cancelFlow)
         }
     }
 }


### PR DESCRIPTION
This PR addresses [the issue](https://github.com/kronor-io/kronor-ios/issues/4) where existential types combined with ViewModifiers were incompatible with AnyView, resulting in the error "Type 'any View' cannot conform to 'View'".

Changes:

- Converted `innerBody` into a `@ViewBuilder` to allow for more dynamic content.
- Refactored `waitingView` to be a generic view, allowing it to conform to the `View` protocol and thus, be compatible with AnyView.
- Shifted `keepOpen` to be a local state

These changes resolve the compatibility issue between existential types and AnyView. After implementing these changes, the error no longer occurs under the conditions that previously caused it.