### PR TITLE
Environment converted to a struct

### DIFF
--- a/Kronor/Kronor/Environment.swift
+++ b/Kronor/Kronor/Environment.swift
@@ -7,46 +7,27 @@
 
 import Foundation
 
-let productionURL = URL(string: "https://kronor.io/v1/graphql")!
-let sandboxURL = URL(string: "https://staging.kronor.io/v1/graphql")!
-
-let productionWsURL = URL(string: "wss://kronor.io/v1/graphql")!
-let sandboxWsURL = URL(string: "wss://staging.kronor.io/v1/graphql")!
-
-
-let productionGatewayURL = URL(string: "https://payment-gateway.kronor.io")!
-let sandboxGatewayURL = URL(string: "https://payment-gateway.staging.kronor.io")!
-
 public extension Kronor {
-    enum Environment {
-        case production
-        case sandbox
+    struct Environment {
+        public let name: String
+        public let apiURL: URL
+        public let websocketURL: URL
+        public let gatewayURL: URL
     }
+}
 
-    static func apiURL(env: Environment) -> URL {
-        switch env {
-        case .production:
-            return productionURL
-        case .sandbox:
-            return sandboxURL
-        }
-    }
-    
-    static func wsApiURL(env: Environment) -> URL {
-        switch env {
-        case .production:
-            return productionWsURL
-        case .sandbox:
-            return sandboxWsURL
-        }
-    }
+public extension Kronor.Environment {
+    static let production = Kronor.Environment(
+        name: "prod",
+        apiURL: URL(string: "https://kronor.io/v1/graphql")!,
+        websocketURL: URL(string: "wss://kronor.io/v1/graphql")!,
+        gatewayURL: URL(string: "https://payment-gateway.kronor.io")!
+    )
 
-    static func gatewayURL(env: Environment) -> URL {
-        switch env {
-        case .production:
-            return productionGatewayURL
-        case .sandbox:
-            return sandboxGatewayURL
-        }
-    }
+    static let sandbox = Kronor.Environment(
+        name: "staging",
+        apiURL: URL(string: "https://staging.kronor.io/v1/graphql")!,
+        websocketURL: URL(string: "wss://staging.kronor.io/v1/graphql")!,
+        gatewayURL: URL(string: "https://payment-gateway.staging.kronor.io")!
+    )
 }

--- a/KronorApi/Client.swift
+++ b/KronorApi/Client.swift
@@ -42,14 +42,13 @@ public extension KronorApi {
     }
     
     static func makeGraphQLClient(env: Kronor.Environment, token: String) -> ApolloClient {
-        let websocketsUrl = Kronor.wsApiURL(env: env)
-        let webSocketClient = WebSocket(url: websocketsUrl, protocol: .graphql_ws)
+        let webSocketClient = WebSocket(url: env.websocketURL, protocol: .graphql_ws)
         let payload: JSONEncodableDictionary = ["headers": ["Authorization": "Bearer " + token]]
         let wsConfig = WebSocketTransport.Configuration(reconnect:true, connectingPayload: payload)
         let webSocketTransport = WebSocketTransport(websocket: webSocketClient, store: store, config: wsConfig)
         
         let httpTransport = RequestChainNetworkTransport(interceptorProvider: provider,
-                                                         endpointURL: Kronor.apiURL(env: env),
+                                                         endpointURL: env.apiURL,
                                                          additionalHeaders: ["Authorization": "Bearer " + token])
         let transport = SplitNetworkTransport(uploadingNetworkTransport: httpTransport, webSocketNetworkTransport: webSocketTransport)
         return ApolloClient(networkTransport: transport, store: store)

--- a/KronorComponents/Common/EmbeddedPaymentViewModel.swift
+++ b/KronorComponents/Common/EmbeddedPaymentViewModel.swift
@@ -77,14 +77,13 @@ class EmbeddedPaymentViewModel: ObservableObject {
         self.onPaymentFailure = onPaymentFailure
         self.paymentMethod = paymentMethod
 
-
-        let gatewayURL = Kronor.gatewayURL(env: env)
+        let gatewayURL = env.gatewayURL
         var components = URLComponents()
         components.scheme = gatewayURL.scheme
         components.host = gatewayURL.host
         components.path = "/payment"
         components.queryItems = [
-            URLQueryItem(name: "env", value: Self.toEnvName(env: env)),
+            URLQueryItem(name: "env", value: env.name),
             URLQueryItem(name: "paymentMethod", value: paymentMethod.getName()),
             URLQueryItem(name: "token", value: sessionToken),
             URLQueryItem(name: "merchantReturnUrl", value: returnURL.absoluteString)
@@ -92,15 +91,6 @@ class EmbeddedPaymentViewModel: ObservableObject {
 
         self.sessionURL = components.url!
         self.returnURL = returnURL
-    }
-    
-    static func toEnvName(env: Kronor.Environment) -> String {
-        switch env {
-        case .sandbox:
-            return "staging"
-        case .production:
-            return "prod"
-        }
     }
 
     func transition(_ event: EmbeddedPaymentStatechart.Event) async {


### PR DESCRIPTION
This pull request implements the proposed changes that has been outlined in issue #6 

Environment has been converted to a struct with the relevant environment properties.

As we were only using the enum to get access to relevant environment properties a struct fits better for our current use case.

The production & sandbox environments has been defined as static properties on the environment itself, giving us the same nice syntax as the caller when defining what environment to use.

closes #6 