### PR TITLE
Removed AnyView usage

### DIFF
--- a/KronorComponents/Common/WrapperView.swift
+++ b/KronorComponents/Common/WrapperView.swift
@@ -7,16 +7,24 @@
 
 import SwiftUI
 
-struct WrapperView: View {
-    var header: any View
-    var contents: () -> any View
+struct WrapperView<Header: View, Content: View>: View {
+    let header: Header
+    let content: Content
+
+    init(
+        header: Header,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.header = header
+        self.content = content()
+    }
 
     var body: some View {
         VStack {
             Spacer()
-            AnyView(self.header)
+            header
             Spacer()
-            AnyView(contents())
+            content
             Spacer()
         }
     }

--- a/KronorComponents/PayPal/PayPalPaymentView.swift
+++ b/KronorComponents/PayPal/PayPalPaymentView.swift
@@ -12,73 +12,60 @@ struct PayPalPaymentView: View {
     
     var body: some View {
         switch viewModel.state {
-
         case .initializing, .paymentRequestInitialized:
-            return AnyView(PayPalWaitingView {
+            PayPalWaitingView {
                 Text(
                     "Creating secure PayPal transaction",
                     bundle: .module,
                     comment:  "A waiting message that indicates the app is communicating with the server"
                 )
                 .font(.subheadline)
-            })
-
+            }
         case .waitingForPayment:
-            return AnyView(PayPalWaitingView {
+            PayPalWaitingView {
                 Text(
                     "Completing your payment, please wait",
                     bundle: .module,
                     comment:  "A waiting message that indicates the app is finilizing the payment"
                 )
                 .font(.subheadline)
-            })
-
+            }
         case .paymentRejected:
-            return AnyView(
-                PaymentRejectedView(viewModel: self.viewModel)
-            )
-
-            
+            PaymentRejectedView(viewModel: self.viewModel)
         case .paymentCompleted:
-            return AnyView(
-                HStack {
-                    Spacer()
-                    Image(systemName: "checkmark.circle")
-                        .foregroundColor(Color.green)
-
-                    Text(
-                        "Payment completed",
-                        bundle: .module,
-                        comment:  "A success message indicating that the payment was completed and the payment session will end"
-                    )
-                    .font(.headline)
+            HStack {
+                Spacer()
+                Image(systemName: "checkmark.circle")
                     .foregroundColor(Color.green)
 
-                    Spacer()
-                }
-            )
+                Text(
+                    "Payment completed",
+                    bundle: .module,
+                    comment:  "A success message indicating that the payment was completed and the payment session will end"
+                )
+                .font(.headline)
+                .foregroundColor(Color.green)
 
-            
+                Spacer()
+            }
         case .errored(_):
-            return AnyView(
-                HStack {
-                    Spacer()
-                    Image(systemName: "xmark.circle")
-                        .foregroundColor(Color.red)
-
-                    Text(
-                        "Could not complete the payment due to an error. Please try again after a short time",
-                        bundle: .module,
-                        comment:  "An error message indicating there was an unexpected error with the payment"
-                    )
-                    .font(.headline)
+            HStack {
+                Spacer()
+                Image(systemName: "xmark.circle")
                     .foregroundColor(Color.red)
-                    .padding(.horizontal)
 
-                    Spacer()
-                }
-                    .padding(.all)
-            )
+                Text(
+                    "Could not complete the payment due to an error. Please try again after a short time",
+                    bundle: .module,
+                    comment:  "An error message indicating there was an unexpected error with the payment"
+                )
+                .font(.headline)
+                .foregroundColor(Color.red)
+                .padding(.horizontal)
+
+                Spacer()
+            }
+            .padding(.all)
         }
     }
 }

--- a/KronorComponents/PayPal/PayPalWaitingView.swift
+++ b/KronorComponents/PayPal/PayPalWaitingView.swift
@@ -7,14 +7,19 @@
 
 import SwiftUI
 
-struct PayPalWaitingView: View {
-    var message: () -> any View
+struct PayPalWaitingView<Content: View>: View {
+    let content: Content
+
+    init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
+
     var body: some View {
         HStack {
             Spacer()
             ProgressView()
                 .padding(.trailing, 10.0)
-            AnyView(message())
+            content
             Spacer()
         }
     }

--- a/KronorComponents/Swish/SwishPaymentView.swift
+++ b/KronorComponents/Swish/SwishPaymentView.swift
@@ -8,153 +8,118 @@
 import SwiftUI
 
 struct SwishPaymentView: View {
-    
     @ObservedObject var viewModel: SwishPaymentViewModel
     
     var body: some View {
+        SwishWrapperView(content: generateContentView)
+    }
+
+    @ViewBuilder func generateContentView() -> some View {
         switch viewModel.state {
         case .promptingMethod:
-            return SwishWrapperView {
-                SwishPromptMethodView(viewModel: viewModel)
-            }
-            
-            
+            SwishPromptMethodView(viewModel: viewModel)
         case .insertingPhoneNumber:
-            return SwishWrapperView {
-                SwishInsertPhoneNumberView(viewModel: viewModel)
-            }
-
-            
+            SwishInsertPhoneNumberView(viewModel: viewModel)
         case .creatingPaymentRequest, .waitingForPaymentRequest:
-            return SwishWrapperView {
-                HStack {
-                    Spacer()
-                    Image(systemName: "hourglass.circle")
-                    Text(
-                        "Creating secure Swish transaction",
-                        bundle: .module,
-                        comment:  "A waiting message that indicates that the app is communicating with the server"
-                    )
-                        .font(.subheadline)
-                    Spacer()
-                }
+            HStack {
+                Spacer()
+                Image(systemName: "hourglass.circle")
+                Text(
+                    "Creating secure Swish transaction",
+                    bundle: .module,
+                    comment:  "A waiting message that indicates that the app is communicating with the server"
+                )
+                .font(.subheadline)
+                Spacer()
             }
-
-            
         case .paymentRequestInitialized(.swishApp):
-            return SwishWrapperView {
-                HStack {
-                    Spacer()
-                    Image(systemName: "arrow.up.forward.app")
-                    Text(
-                        "Opening the swish app",
-                        bundle: .module,
-                        comment:  "Indicates that this app is prompting the user to open the Swish app in the same device"
-                    )
-                        .font(.subheadline)
-                        
-                    Spacer()
-                }
-            }
+            HStack {
+                Spacer()
+                Image(systemName: "arrow.up.forward.app")
+                Text(
+                    "Opening the swish app",
+                    bundle: .module,
+                    comment:  "Indicates that this app is prompting the user to open the Swish app in the same device"
+                )
+                .font(.subheadline)
 
-            
+                Spacer()
+            }
         case .paymentRequestInitialized(.qrCode):
-            return SwishWrapperView {
-                if let qrCode = viewModel.qrCode {
-                    return AnyView(SwishQRView(qrCode: qrCode))
-                } else {
-                    return HStack {
-                        Spacer()
-                        Image(systemName: "qrcode.viewfinder")
-                        Text(
-                            "Generating QR code",
-                            bundle: .module,
-                            comment:  "A waiting message indicating that a new QR code image is being generated"
-                        )
-                            .font(.subheadline)
-                            
-                        Spacer()
-                    }
+            if let qrCode = viewModel.qrCode {
+                SwishQRView(qrCode: qrCode)
+            } else {
+                HStack {
+                    Spacer()
+                    Image(systemName: "qrcode.viewfinder")
+                    Text(
+                        "Generating QR code",
+                        bundle: .module,
+                        comment:  "A waiting message indicating that a new QR code image is being generated"
+                    )
+                    .font(.subheadline)
+
+                    Spacer()
                 }
             }
-
-            
         case .paymentRequestInitialized(.phoneNumber):
-            return SwishWrapperView {
-                HStack {
-                    Spacer()
-                    Image(systemName: "arrow.up.forward.app")
-                    Text(
-                        "You can pay with the Swish app now",
-                        bundle: .module,
-                        comment:  "A waiting message indicating that the customer should open the Swish app in another phone"
-                    )
-                        .font(.headline)
-                        
-                    Spacer()
-                }
+            HStack {
+                Spacer()
+                Image(systemName: "arrow.up.forward.app")
+                Text(
+                    "You can pay with the Swish app now",
+                    bundle: .module,
+                    comment:  "A waiting message indicating that the customer should open the Swish app in another phone"
+                )
+                .font(.headline)
+
+                Spacer()
             }
-
-
         case .waitingForPayment:
-            return SwishWrapperView {
-                HStack {
-                    Spacer()
-                    Image(systemName: "hourglass.circle")
-                    Text(
-                        "Completing payment",
-                        bundle: .module,
-                        comment:  "A waiting message indicating that the customer should complete the payment in the Swish app"
-                    )
-                        .font(.subheadline)
-                    Spacer()
-                }
+            HStack {
+                Spacer()
+                Image(systemName: "hourglass.circle")
+                Text(
+                    "Completing payment",
+                    bundle: .module,
+                    comment:  "A waiting message indicating that the customer should complete the payment in the Swish app"
+                )
+                .font(.subheadline)
+                Spacer()
             }
-
-
         case .paymentRejected:
-            return SwishWrapperView {
-                PaymentRejectedView(viewModel: self.viewModel)
-            }
-
-            
+            PaymentRejectedView(viewModel: self.viewModel)
         case .paymentCompleted:
-            return SwishWrapperView {
-                HStack {
-                    Spacer()
-                    Image(systemName: "checkmark.circle")
-                        .foregroundColor(Color.green)
-                        
-                    Text(
-                        "Payment completed",
-                        bundle: .module,
-                        comment:  "A success message indicating that the payment was completed and the payment session will end"
-                    )
-                        .font(.headline)
-                        .foregroundColor(Color.green)
-                        
-                    Spacer()
-                }
-            }
+            HStack {
+                Spacer()
+                Image(systemName: "checkmark.circle")
+                    .foregroundColor(Color.green)
 
-            
+                Text(
+                    "Payment completed",
+                    bundle: .module,
+                    comment:  "A success message indicating that the payment was completed and the payment session will end"
+                )
+                .font(.headline)
+                .foregroundColor(Color.green)
+
+                Spacer()
+            }
         case .errored(_):
-            return SwishWrapperView {
-                HStack {
-                    Spacer()
-                    Image(systemName: "xmark.circle")
-                        .foregroundColor(Color.red)
-                        
-                    Text(
-                        "Could not complete the payment due to an error. Please try again after a short time",
-                        bundle: .module,
-                        comment:  "An error message indicating there was an unexpected error with the payment"
-                    )
-                        .font(.headline)
-                        .foregroundColor(Color.red)
-                        
-                    Spacer()
-                }
+            HStack {
+                Spacer()
+                Image(systemName: "xmark.circle")
+                    .foregroundColor(Color.red)
+
+                Text(
+                    "Could not complete the payment due to an error. Please try again after a short time",
+                    bundle: .module,
+                    comment:  "An error message indicating there was an unexpected error with the payment"
+                )
+                .font(.headline)
+                .foregroundColor(Color.red)
+
+                Spacer()
             }
         }
     }

--- a/KronorComponents/Swish/SwishWrapperView.swift
+++ b/KronorComponents/Swish/SwishWrapperView.swift
@@ -7,15 +7,19 @@
 
 import SwiftUI
 
-struct SwishWrapperView: View {
-    var contents: () -> any View
+struct SwishWrapperView<Content: View>: View {
+    let content: Content
+
+    init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
 
     var body: some View {
         VStack {
             Spacer()
             SwishHeaderView()
             Spacer()
-            AnyView(contents())
+            content
             Spacer()
         }
     }


### PR DESCRIPTION
This pull request is resolving the issue #8 to remove `AnyView` usage 

With a mix of `@ViewBuilder` and generics it was possible to remove all instances of `AnyView` used.

I have used the pattern of injecting a `@ViewBuilder` closure in the init and resolving the view immediately - this is the preferred and more performant approach when dynamically resolving the view is not necessary.