### PR TITLE
Injection of network functionality for payment view models

### DIFF
--- a/KronorComponents/Common/EmbeddedPaymentNetworking.swift
+++ b/KronorComponents/Common/EmbeddedPaymentNetworking.swift
@@ -1,0 +1,27 @@
+//
+//  EmbeddedPaymentNetworking.swift
+//  
+//
+//  Created by Niclas Heltoft on 17/07/2023.
+//
+
+import Foundation
+import Kronor
+import KronorApi
+
+protocol EmbeddedPaymentNetworking: PaymentNetworking {
+    func createMobilePayPaymentRequest(
+        returnURL: URL,
+        device: Kronor.Device?
+    ) async -> Result<String, KronorApi.KronorError>
+
+    func createCreditCardPaymentRequest(
+        returnURL: URL,
+        device: Kronor.Device?
+    ) async -> Result<String, KronorApi.KronorError>
+    
+    func createVippsRequest(
+        returnURL: URL,
+        device: Kronor.Device?
+    ) async -> Result<String, KronorApi.KronorError>
+}

--- a/KronorComponents/Common/EmbeddedPaymentView.swift
+++ b/KronorComponents/Common/EmbeddedPaymentView.swift
@@ -126,6 +126,10 @@ struct EmbeddedPaymentView_Previews: PreviewProvider {
             env: .sandbox,
             sessionToken: "dummy",
             stateMachine: machine,
+            networking: KronorEmbeddedPaymentNetworking(
+                env: .sandbox,
+                token: "dummy"
+            ),
             paymentMethod: .mobilePay,
             returnURL: URL(string: "io.kronortest://")!,
             onPaymentFailure: {},

--- a/KronorComponents/Common/KronorEmbeddedPaymentNetworking.swift
+++ b/KronorComponents/Common/KronorEmbeddedPaymentNetworking.swift
@@ -1,0 +1,79 @@
+//
+//  KronorEmbeddedPaymentNetworking.swift
+//  
+//
+//  Created by Niclas Heltoft on 17/07/2023.
+//
+
+import Foundation
+import Kronor
+import KronorApi
+import Apollo
+
+final class KronorEmbeddedPaymentNetworking: KronorPaymentNetworking, EmbeddedPaymentNetworking {
+    func createMobilePayPaymentRequest(
+        returnURL: URL,
+        device: Kronor.Device?
+    ) async -> Result<String, KronorApi.KronorError> {
+        let input = KronorApi.MobilePayPaymentInput(
+            idempotencyKey: UUID().uuidString,
+            returnUrl: returnURL.absoluteString
+        )
+
+        var deviceInfo = device.map(makeDeviceInfo)
+        if deviceInfo == nil {
+            let def = await Kronor.detectDevice()
+            deviceInfo = makeDeviceInfo(device: def)
+        }
+
+        return await KronorApi.createMobilePayPaymentRequest(
+            client: client,
+            input: input,
+            deviceInfo: deviceInfo!
+        )
+    }
+
+    func createCreditCardPaymentRequest(
+        returnURL: URL,
+        device: Kronor.Device?
+    ) async -> Result<String, KronorApi.KronorError> {
+        let input = KronorApi.CreditCardPaymentInput(
+            idempotencyKey: UUID().uuidString,
+            returnUrl: returnURL.absoluteString
+        )
+
+        var deviceInfo = device.map(makeDeviceInfo)
+        if deviceInfo == nil {
+            let def = await Kronor.detectDevice()
+            deviceInfo = makeDeviceInfo(device: def)
+        }
+
+        return await KronorApi.createCreditCardPaymentRequest(
+            client: client,
+            input: input,
+            deviceInfo: deviceInfo!
+        )
+    }
+
+    func createVippsRequest(
+        returnURL: URL,
+        device: Kronor.Device?
+    ) async -> Result<String, KronorApi.KronorError> {
+        let input = KronorApi.VippsPaymentInput(
+            idempotencyKey: UUID().uuidString,
+            returnUrl: returnURL.absoluteString
+        )
+
+        var deviceInfo = device.map(makeDeviceInfo)
+        if deviceInfo == nil {
+            let def = await Kronor.detectDevice()
+            deviceInfo = makeDeviceInfo(device: def)
+        }
+
+        return await KronorApi.createVippsPaymentRequest(
+            client: client,
+            input: input,
+            deviceInfo: deviceInfo!
+        )
+    }
+}

--- a/KronorComponents/Common/KronorPaymentNetworking.swift
+++ b/KronorComponents/Common/KronorPaymentNetworking.swift
@@ -1,0 +1,48 @@
+//
+//  KronorPaymentNetworking.swift
+//  
+//
+//  Created by Niclas Heltoft on 17/07/2023.
+//
+
+import Foundation
+import Apollo
+import KronorApi
+import Kronor
+
+class KronorPaymentNetworking: PaymentNetworking {
+    let client: ApolloClient
+
+    init(
+        env: Kronor.Environment,
+        token: String
+    ) {
+        self.client = KronorApi.makeGraphQLClient(
+            env: env,
+            token: token
+        )
+    }
+
+    func subscribeToPaymentStatus(
+        resultHandler: @escaping (Result<GraphQLResult<KronorApi.PaymentStatusSubscription.Data>, Error>) -> Void
+    ) -> Cancellable {
+        client.subscribe(
+            subscription: KronorApi.PaymentStatusSubscription(),
+            resultHandler: resultHandler
+        )
+    }
+
+    func cancelSessionPayments() async -> Result<(), Never> {
+        await withCheckedContinuation { continuation in
+            client.perform(
+                mutation: KronorApi.CancelSessionPaymentsMutation(
+                    idempotencyKey: UUID().uuidString
+                )
+            ) { data in
+                continuation.resume(
+                    returning: .success(())
+                )
+            }
+        }
+    }
+}

--- a/KronorComponents/Common/PaymentNetworking.swift
+++ b/KronorComponents/Common/PaymentNetworking.swift
@@ -1,0 +1,18 @@
+//
+//  PaymentNetworking.swift
+//  
+//
+//  Created by Niclas Heltoft on 17/07/2023.
+//
+
+import Foundation
+import Apollo
+import KronorApi
+
+protocol PaymentNetworking {
+    func subscribeToPaymentStatus(
+        resultHandler: @escaping GraphQLResultHandler<KronorApi.PaymentStatusSubscription.Data>
+    ) -> Cancellable
+
+    func cancelSessionPayments() async -> Result<(), Never>
+}

--- a/KronorComponents/CreditCard/CreditCardComponent.swift
+++ b/KronorComponents/CreditCard/CreditCardComponent.swift
@@ -19,11 +19,15 @@ public struct CreditCardComponent: View {
                 onPaymentSuccess: @escaping (_ paymentId: String) -> ()
     ) {
         let machine = EmbeddedPaymentStatechart.makeStateMachine()
-
+        let networking = KronorEmbeddedPaymentNetworking(
+            env: env,
+            token: sessionToken
+        )
         let viewModel = EmbeddedPaymentViewModel(
             env: env,
             sessionToken: sessionToken,
             stateMachine: machine,
+            networking: networking,
             paymentMethod: .creditCard,
             returnURL: returnURL,
             device: device,

--- a/KronorComponents/CreditCard/CreditCardHeaderView.swift
+++ b/KronorComponents/CreditCard/CreditCardHeaderView.swift
@@ -36,10 +36,17 @@ struct CreditCardHeaderView: View {
 struct CreditCardHeaderView_Previews: PreviewProvider {
     static var previews: some View {
         let machine = EmbeddedPaymentStatechart.makeStateMachine()
+        let env = Kronor.Environment.sandbox
+        let token = "dummy"
+        let networking = KronorEmbeddedPaymentNetworking(
+            env: env,
+            token: token
+        )
         let viewModel = EmbeddedPaymentViewModel(
-            env: .sandbox,
-            sessionToken: "dummy",
+            env: env,
+            sessionToken: token,
             stateMachine: machine,
+            networking: networking,
             paymentMethod: .mobilePay,
             returnURL: URL(string: "io.kronortest://")!,
             onPaymentFailure: {},
@@ -55,9 +62,10 @@ struct CreditCardHeaderView_Previews: PreviewProvider {
             initial: .errored(error: .usageError(error: KronorApi.APIError(errors: [], extensions: [:])))
         )
         let viewModel2 = EmbeddedPaymentViewModel(
-            env: .sandbox,
-            sessionToken: "dummy",
+            env: env,
+            sessionToken: token,
             stateMachine: machine2,
+            networking: networking,
             paymentMethod: .mobilePay,
             returnURL: URL(string: "io.kronortest://")!,
             onPaymentFailure: {},

--- a/KronorComponents/CreditCard/CreditCardWaitingView.swift
+++ b/KronorComponents/CreditCard/CreditCardWaitingView.swift
@@ -30,6 +30,10 @@ struct CreditCardWaitingView_Previews: PreviewProvider {
             env: .sandbox,
             sessionToken: "dummy",
             stateMachine: machine,
+            networking: KronorEmbeddedPaymentNetworking(
+                env: .sandbox,
+                token: "dummy"
+            ),
             paymentMethod: .mobilePay,
             returnURL: URL(string: "io.kronortest://")!,
             onPaymentFailure: {},

--- a/KronorComponents/Fallback/FallbackComponent.swift
+++ b/KronorComponents/Fallback/FallbackComponent.swift
@@ -20,11 +20,15 @@ public struct FallbackComponent: View {
                 onPaymentSuccess: @escaping (_ paymentId: String) -> ()
     ) {
         let machine = EmbeddedPaymentStatechart.makeStateMachine()
-
+        let networking = KronorEmbeddedPaymentNetworking(
+            env: env,
+            token: sessionToken
+        )
         let viewModel = EmbeddedPaymentViewModel(
             env: env,
             sessionToken: sessionToken,
             stateMachine: machine,
+            networking: networking,
             paymentMethod: .fallback(name: paymentMethodName),
             returnURL: returnURL,
             device: device,

--- a/KronorComponents/MobilePay/MobilePayComponent.swift
+++ b/KronorComponents/MobilePay/MobilePayComponent.swift
@@ -19,11 +19,15 @@ public struct MobilePayComponent: View {
                 onPaymentSuccess: @escaping (_ paymentId: String) -> ()
     ) {
         let machine = EmbeddedPaymentStatechart.makeStateMachine()
-
+        let networking = KronorEmbeddedPaymentNetworking(
+            env: env,
+            token: sessionToken
+        )
         let viewModel = EmbeddedPaymentViewModel(
             env: env,
             sessionToken: sessionToken,
             stateMachine: machine,
+            networking: networking,
             paymentMethod: .mobilePay,
             returnURL: returnURL,
             device: device,

--- a/KronorComponents/PayPal/KronorPayPalPaymentNetworking.swift
+++ b/KronorComponents/PayPal/KronorPayPalPaymentNetworking.swift
@@ -1,0 +1,43 @@
+//
+//  KronorPayPalPaymentNetworking.swift
+//  
+//
+//  Created by Niclas Heltoft on 17/07/2023.
+//
+
+import Foundation
+import Kronor
+import KronorApi
+
+final class KronorPayPalPaymentNetworking: KronorPaymentNetworking, PayPalPaymentNetworking {
+    func sendPayPalNonce(
+        input: KronorApi.SupplyPayPalPaymentMethodIdInput
+    ) async -> Result<(), KronorApi.KronorError> {
+        await KronorApi.sendPayPalNonce(
+            client: client,
+            input: input
+        )
+    }
+
+    func createPayPalPaymentRequest(
+        returnURL: URL,
+        device: Kronor.Device?
+    ) async -> Result<KronorApi.PayPalData, KronorApi.KronorError> {
+        let input = KronorApi.PayPalPaymentInput(
+            idempotencyKey: UUID().uuidString,
+            returnUrl: returnURL.absoluteString
+        )
+
+        var deviceInfo = device.map(makeDeviceInfo)
+        if deviceInfo == nil {
+            let def = await Kronor.detectDevice()
+            deviceInfo = makeDeviceInfo(device: def)
+        }
+
+        return await KronorApi.createPayPalPaymentRequest(
+            client: client,
+            input: input,
+            deviceInfo: deviceInfo!
+        )
+    }
+}

--- a/KronorComponents/PayPal/PayPalComponent.swift
+++ b/KronorComponents/PayPal/PayPalComponent.swift
@@ -19,11 +19,13 @@ public struct PayPalComponent: View {
                 onPaymentSuccess: @escaping (_ paymentId: String) -> ()
     ) {
         let machine = PayPalStatechart.makeStateMachine()
-
-        let viewModel = PayPalViewModel(
+        let networking = KronorPayPalPaymentNetworking(
             env: env,
-            sessionToken: sessionToken,
+            token: sessionToken
+        )
+        let viewModel = PayPalViewModel(
             stateMachine: machine,
+            networking: networking,
             returnURL: returnURL,
             device: device,
             onPaymentFailure: onPaymentFailure,

--- a/KronorComponents/PayPal/PayPalPaymentNetworking.swift
+++ b/KronorComponents/PayPal/PayPalPaymentNetworking.swift
@@ -1,0 +1,21 @@
+//
+//  PayPalPaymentNetworking.swift
+//  
+//
+//  Created by Niclas Heltoft on 17/07/2023.
+//
+
+import Foundation
+import Kronor
+import KronorApi
+
+protocol PayPalPaymentNetworking: PaymentNetworking {
+    func sendPayPalNonce(
+        input: KronorApi.SupplyPayPalPaymentMethodIdInput
+    ) async -> Result<(), KronorApi.KronorError>
+
+    func createPayPalPaymentRequest(
+        returnURL: URL,
+        device: Kronor.Device?
+    ) async -> Result<KronorApi.PayPalData, KronorApi.KronorError>
+}

--- a/KronorComponents/PayPal/PayPalPaymentView.swift
+++ b/KronorComponents/PayPal/PayPalPaymentView.swift
@@ -73,10 +73,13 @@ struct PayPalPaymentView: View {
 struct PayPalPaymentView_Previews: PreviewProvider {
     static var previews: some View {
         let machine = PayPalStatechart.makeStateMachine()
-        let viewModel = PayPalViewModel(
+        let networking = KronorPayPalPaymentNetworking(
             env: .sandbox,
-            sessionToken: "dummy",
+            token: "dummy"
+        )
+        let viewModel = PayPalViewModel(
             stateMachine: machine,
+            networking: networking,
             returnURL: URL(string: "io.kronortest://")!,
             onPaymentFailure: {},
             onPaymentSuccess: {paymentId in }

--- a/KronorComponents/Swish/KronorSwishPaymentNetworking.swift
+++ b/KronorComponents/Swish/KronorSwishPaymentNetworking.swift
@@ -1,0 +1,60 @@
+//
+//  KronorSwishPaymentNetworking.swift
+//  
+//
+//  Created by Niclas Heltoft on 17/07/2023.
+//
+
+import Foundation
+import Kronor
+import KronorApi
+
+final class KronorSwishPaymentNetworking: KronorPaymentNetworking, SwishPaymentNetworking {
+    func createMcomPaymentRequest(
+        returnURL: URL,
+        device: Kronor.Device?
+    ) async -> Result<String, KronorApi.KronorError> {
+        let input = KronorApi.SwishPaymentInput(
+            flow: "mcom",
+            idempotencyKey: UUID().uuidString,
+            returnUrl: returnURL.absoluteString
+        )
+
+        var deviceInfo = device.map(makeDeviceInfo)
+        if deviceInfo == nil {
+            let def = await Kronor.detectDevice()
+            deviceInfo = makeDeviceInfo(device: def)
+        }
+
+        return await KronorApi.createSwishPaymentRequest(
+            client: client,
+            input: input,
+            deviceInfo: deviceInfo!
+        )
+    }
+
+    func createEcomPaymentRequest(
+        phoneNumber: String,
+        returnURL: URL,
+        device: Kronor.Device?
+    ) async -> Result<String, KronorApi.KronorError> {
+        let input = KronorApi.SwishPaymentInput(
+            customerSwishNumber: .some(phoneNumber),
+            flow: "ecom",
+            idempotencyKey: UUID().uuidString,
+            returnUrl: returnURL.absoluteString
+        )
+
+        var deviceInfo = device.map(makeDeviceInfo)
+        if deviceInfo == nil {
+            let def = await Kronor.detectDevice()
+            deviceInfo = makeDeviceInfo(device: def)
+        }
+
+        return await KronorApi.createSwishPaymentRequest(
+            client: client,
+            input: input,
+            deviceInfo: deviceInfo!
+        )
+    }
+}

--- a/KronorComponents/Swish/SwishComponent.swift
+++ b/KronorComponents/Swish/SwishComponent.swift
@@ -19,10 +19,13 @@ public struct SwishComponent: View {
                 onPaymentSuccess: @escaping (_ paymentId: String) -> ()
     ) {
         let machine = SwishStatechart.makeStateMachine()
-        self.viewModel = SwishPaymentViewModel(
+        let networking = KronorSwishPaymentNetworking(
             env: env,
-            sessionToken: sessionToken,
+            token: sessionToken
+        )
+        self.viewModel = SwishPaymentViewModel(
             stateMachine: machine,
+            networking: networking,
             returnURL: returnURL,
             device: device,
             onPaymentFailure: onPaymentFailure,

--- a/KronorComponents/Swish/SwishInsertPhoneNumberView.swift
+++ b/KronorComponents/Swish/SwishInsertPhoneNumberView.swift
@@ -46,12 +46,15 @@ struct SwishInsertPhoneNumberView: View {
 
 struct SwishInsertPhoneNumberView_Previews: PreviewProvider {
     static let machine = SwishStatechart.makeStateMachine()
+    static let networking = KronorSwishPaymentNetworking(
+        env: .sandbox,
+        token: "dummy"
+    )
     
     static var previews: some View {
         let viewModel = SwishPaymentViewModel(
-            env: .sandbox,
-            sessionToken: "dummy",
             stateMachine: machine,
+            networking: networking,
             returnURL: URL(string: "io.kronortest://")!,
             onPaymentFailure: {},
             onPaymentSuccess: {paymentId in }

--- a/KronorComponents/Swish/SwishPaymentNetworking.swift
+++ b/KronorComponents/Swish/SwishPaymentNetworking.swift
@@ -1,0 +1,23 @@
+//
+//  SwishPaymentNetworking.swift
+//  
+//
+//  Created by Niclas Heltoft on 17/07/2023.
+//
+
+import Foundation
+import Kronor
+import KronorApi
+
+protocol SwishPaymentNetworking: PaymentNetworking {
+    func createMcomPaymentRequest(
+        returnURL: URL,
+        device: Kronor.Device?
+    ) async -> Result<String, KronorApi.KronorError>
+
+    func createEcomPaymentRequest(
+        phoneNumber: String,
+        returnURL: URL,
+        device: Kronor.Device?
+    ) async -> Result<String, KronorApi.KronorError>
+}

--- a/KronorComponents/Swish/SwishPaymentView.swift
+++ b/KronorComponents/Swish/SwishPaymentView.swift
@@ -126,14 +126,18 @@ struct SwishPaymentView: View {
 }
 
 struct SwishPaymentView_Previews: PreviewProvider {
+    static let networking = KronorSwishPaymentNetworking(
+        env: .sandbox,
+        token: "dummy"
+    )
+
     static var previews: some View {
         
         // prompt
         let machine = SwishStatechart.makeStateMachine()
         let viewModel = SwishPaymentViewModel(
-            env: .sandbox,
-            sessionToken: "dummy",
             stateMachine: machine,
+            networking: networking,
             returnURL: URL(string: "io.kronortest://")!,
             onPaymentFailure: {},
             onPaymentSuccess: {paymentId in }
@@ -144,9 +148,8 @@ struct SwishPaymentView_Previews: PreviewProvider {
         // creatingPaymentRequest
         let machine2 = SwishStatechart.makeStateMachineWithInitialState(initial: .creatingPaymentRequest(selected: .swishApp))
         let viewModel2 = SwishPaymentViewModel(
-            env: .sandbox,
-            sessionToken: "dummy",
             stateMachine: machine2,
+            networking: networking,
             returnURL: URL(string: "io.kronortest://")!,
             onPaymentFailure: {},
             onPaymentSuccess: {paymentId in }
@@ -157,9 +160,8 @@ struct SwishPaymentView_Previews: PreviewProvider {
         // creatingPaymentRequest
         let machine3 = SwishStatechart.makeStateMachineWithInitialState(initial: .waitingForPaymentRequest(selected: .swishApp))
         let viewModel3 = SwishPaymentViewModel(
-            env: .sandbox,
-            sessionToken: "dummy",
             stateMachine: machine3,
+            networking: networking,
             returnURL: URL(string: "io.kronortest://")!,
             onPaymentFailure: {},
             onPaymentSuccess: {paymentId in }
@@ -170,9 +172,8 @@ struct SwishPaymentView_Previews: PreviewProvider {
         // waitingForPayment
         let machine4 = SwishStatechart.makeStateMachineWithInitialState(initial: .waitingForPayment)
         let viewModel4 = SwishPaymentViewModel(
-            env: .sandbox,
-            sessionToken: "dummy",
             stateMachine: machine4,
+            networking: networking,
             returnURL: URL(string: "io.kronortest://")!,
             onPaymentFailure: {},
             onPaymentSuccess: {paymentId in }
@@ -183,9 +184,8 @@ struct SwishPaymentView_Previews: PreviewProvider {
         // paymentRequestInitialized (app)
         let machine5 = SwishStatechart.makeStateMachineWithInitialState(initial: .paymentRequestInitialized(selected: .swishApp))
         let viewModel5 = SwishPaymentViewModel(
-            env: .sandbox,
-            sessionToken: "dummy",
             stateMachine: machine5,
+            networking: networking,
             returnURL: URL(string: "io.kronortest://")!,
             onPaymentFailure: {},
             onPaymentSuccess: {paymentId in }
@@ -196,9 +196,8 @@ struct SwishPaymentView_Previews: PreviewProvider {
         // paymentRequestInitialized (qr)
         let machine6 = SwishStatechart.makeStateMachineWithInitialState(initial: .paymentRequestInitialized(selected: .qrCode))
         let viewModel6 = SwishPaymentViewModel(
-            env: .sandbox,
-            sessionToken: "dummy",
             stateMachine: machine6,
+            networking: networking,
             returnURL: URL(string: "io.kronortest://")!,
             onPaymentFailure: {},
             onPaymentSuccess: {paymentId in }
@@ -209,9 +208,8 @@ struct SwishPaymentView_Previews: PreviewProvider {
         // paymentRequestInitialized (phone)
         let machine7 = SwishStatechart.makeStateMachineWithInitialState(initial: .paymentRequestInitialized(selected: .phoneNumber))
         let viewModel7 = SwishPaymentViewModel(
-            env: .sandbox,
-            sessionToken: "dummy",
             stateMachine: machine7,
+            networking: networking,
             returnURL: URL(string: "io.kronortest://")!,
             onPaymentFailure: {},
             onPaymentSuccess: {paymentId in }
@@ -222,9 +220,8 @@ struct SwishPaymentView_Previews: PreviewProvider {
         // paymentRejected
         let machine8 = SwishStatechart.makeStateMachineWithInitialState(initial: .paymentRejected)
         let viewModel8 = SwishPaymentViewModel(
-            env: .sandbox,
-            sessionToken: "dummy",
             stateMachine: machine8,
+            networking: networking,
             returnURL: URL(string: "io.kronortest://")!,
             onPaymentFailure: {},
             onPaymentSuccess: {paymentId in }
@@ -235,9 +232,8 @@ struct SwishPaymentView_Previews: PreviewProvider {
         // paymentCompleted
         let machine9 = SwishStatechart.makeStateMachineWithInitialState(initial: .paymentCompleted)
         let viewModel9 = SwishPaymentViewModel(
-            env: .sandbox,
-            sessionToken: "dummy",
             stateMachine: machine9,
+            networking: networking,
             returnURL: URL(string: "io.kronortest://")!,
             onPaymentFailure: {},
             onPaymentSuccess: {paymentId in }

--- a/KronorComponents/Swish/SwishPromptMethodView.swift
+++ b/KronorComponents/Swish/SwishPromptMethodView.swift
@@ -73,12 +73,15 @@ struct SwishPromptMethodView: View {
 
 struct SwishPromptMethodView_Previews: PreviewProvider {
     static let machine = SwishStatechart.makeStateMachine()
+    static let networking = KronorSwishPaymentNetworking(
+        env: .sandbox,
+        token: "dummy"
+    )
     
     static var previews: some View {
         let viewModel = SwishPaymentViewModel(
-            env: .sandbox,
-            sessionToken: "dummy",
             stateMachine: machine,
+            networking: networking,
             returnURL: URL(string: "io.kronortest://")!,
             onPaymentFailure: {},
             onPaymentSuccess: {paymentId in }

--- a/KronorComponents/Vipps/VippsComponent.swift
+++ b/KronorComponents/Vipps/VippsComponent.swift
@@ -19,11 +19,15 @@ public struct VippsComponent: View {
                 onPaymentSuccess: @escaping (_ paymentId: String) -> ()
     ) {
         let machine = EmbeddedPaymentStatechart.makeStateMachine()
-
+        let networking = KronorEmbeddedPaymentNetworking(
+            env: env,
+            token: sessionToken
+        )
         let viewModel = EmbeddedPaymentViewModel(
             env: env,
             sessionToken: sessionToken,
             stateMachine: machine,
+            networking: networking,
             paymentMethod: .vipps,
             returnURL: returnURL,
             device: device,


### PR DESCRIPTION
This pull request aims to solve issue #10 regarding injection of network functionality into the payment view models. 

Network functionality for the different payment types has been separated out into protocols all conforming to the new `PaymentNetworking` protocol. This benefits us by having networking code clearly separated while being able to share common networking functionality from the `PaymentNetworking` protocol.

The main goal of this change is that it will allow us to introduce tests of the state logic in the view models without doing any network requests by injecting mocks instead.