### PR TITLE
Do not cancel session payments for embedded payment methods

### DIFF
--- a/KronorComponents/Common/EmbeddedPaymentStatechart.swift
+++ b/KronorComponents/Common/EmbeddedPaymentStatechart.swift
@@ -39,7 +39,6 @@ final class EmbeddedPaymentStatechart : StateMachineBuilder {
     enum SideEffect {
         case createPaymentRequest
         case openEmbeddedSite
-        case cancelPaymentRequest
         case subscribeToPaymentStatus (waitToken: String)
         case notifyPaymentSuccess
         case notifyPaymentFailure


### PR DESCRIPTION
Using the cancel API call creates race conditions in which clients cancel before finishing a payment.

This should solve certain cases of duplicate payments in combination with newPaymentSessionWithReferenceCheck