### PR TITLE
Added a failure reason to onFailure callback

### DIFF
--- a/KronorComponents/Common/EmbeddedPaymentViewModel.swift
+++ b/KronorComponents/Common/EmbeddedPaymentViewModel.swift
@@ -55,7 +55,7 @@ class EmbeddedPaymentViewModel: ObservableObject {
 
     private var paymentMethod: SupportedEmbeddedMethod
     private var device: Kronor.Device?
-    private var onPaymentFailure: () -> ()
+    private var onPaymentFailure: (_ reason: FailureReason) -> ()
     private var onPaymentSuccess: (_ paymentId: String) -> ()
     internal let sessionURL: URL
     internal let returnURL: URL
@@ -70,7 +70,7 @@ class EmbeddedPaymentViewModel: ObservableObject {
          paymentMethod: SupportedEmbeddedMethod,
          returnURL: URL,
          device: Kronor.Device? = nil,
-         onPaymentFailure: @escaping () -> (),
+         onPaymentFailure: @escaping (_ reason: FailureReason) -> (),
          onPaymentSuccess: @escaping (_ paymentId: String) -> ()
     ) {
         self.stateMachine = stateMachine
@@ -177,7 +177,7 @@ class EmbeddedPaymentViewModel: ObservableObject {
             Self.logger.trace("performing notifyPaymentFailure")
             self.subscription?.cancel()
             await MainActor.run {
-                self.onPaymentFailure()
+                self.onPaymentFailure(.declined)
             }
 
 
@@ -185,7 +185,7 @@ class EmbeddedPaymentViewModel: ObservableObject {
             Self.logger.trace("performing cancelAndNotifyFailure")
             self.subscription?.cancel()
             await MainActor.run {
-                self.onPaymentFailure()
+                self.onPaymentFailure(.cancelled)
             }
 
             

--- a/KronorComponents/Common/FailureReason.swift
+++ b/KronorComponents/Common/FailureReason.swift
@@ -1,0 +1,11 @@
+//
+//  FailureReason.swift
+//
+//
+//  Created by lorenzo on 2023-09-29.
+//
+
+public enum FailureReason {
+    case cancelled
+    case declined
+}

--- a/KronorComponents/Common/Preview.swift
+++ b/KronorComponents/Common/Preview.swift
@@ -35,7 +35,7 @@ enum Preview {
             networking: networking,
             paymentMethod: paymentMethod,
             returnURL: returnURL,
-            onPaymentFailure: {reason in },
+            onPaymentFailure: { reason in },
             onPaymentSuccess: { paymentId in }
         )
     }
@@ -57,7 +57,7 @@ enum Preview {
             stateMachine: machine,
             networking: networking,
             returnURL: returnURL,
-            onPaymentFailure: {reason in },
+            onPaymentFailure: { reason in },
             onPaymentSuccess: { paymentId in }
         )
     }

--- a/KronorComponents/Common/Preview.swift
+++ b/KronorComponents/Common/Preview.swift
@@ -35,7 +35,7 @@ enum Preview {
             networking: networking,
             paymentMethod: paymentMethod,
             returnURL: returnURL,
-            onPaymentFailure: {},
+            onPaymentFailure: {reason in },
             onPaymentSuccess: { paymentId in }
         )
     }
@@ -57,7 +57,7 @@ enum Preview {
             stateMachine: machine,
             networking: networking,
             returnURL: returnURL,
-            onPaymentFailure: {},
+            onPaymentFailure: {reason in },
             onPaymentSuccess: { paymentId in }
         )
     }

--- a/KronorComponents/CreditCard/CreditCardComponent.swift
+++ b/KronorComponents/CreditCard/CreditCardComponent.swift
@@ -15,7 +15,7 @@ public struct CreditCardComponent: View {
                 sessionToken: String,
                 returnURL: URL,
                 device: Kronor.Device? = nil,
-                onPaymentFailure: @escaping () -> (),
+                onPaymentFailure: @escaping (_ reason: FailureReason) -> (),
                 onPaymentSuccess: @escaping (_ paymentId: String) -> ()
     ) {
         let machine = EmbeddedPaymentStatechart.makeStateMachine()
@@ -55,8 +55,8 @@ struct CreditCardComponent_Previews: PreviewProvider {
             env: Preview.env,
             sessionToken: Preview.token,
             returnURL: Preview.returnURL,
-            onPaymentFailure: {
-                print("failed!")
+            onPaymentFailure: { reason in
+                print("failed: \(reason)")
             }
         ) { paymentId in
             print("done: \(paymentId)")

--- a/KronorComponents/Fallback/FallbackComponent.swift
+++ b/KronorComponents/Fallback/FallbackComponent.swift
@@ -16,7 +16,7 @@ public struct FallbackComponent: View {
                 paymentMethodName: String,
                 returnURL: URL,
                 device: Kronor.Device? = nil,
-                onPaymentFailure: @escaping () -> (),
+                onPaymentFailure: @escaping (_ reason: FailureReason) -> (),
                 onPaymentSuccess: @escaping (_ paymentId: String) -> ()
     ) {
         let machine = EmbeddedPaymentStatechart.makeStateMachine()
@@ -60,8 +60,8 @@ struct FallbackComponent_Previews: PreviewProvider {
             sessionToken: Preview.token,
             paymentMethodName: "swish",
             returnURL: Preview.returnURL,
-            onPaymentFailure: {
-                print("failed!")
+            onPaymentFailure: { reason in
+                print("failed: \(reason)")
             }
         ) { paymentId in
             print("done: \(paymentId)")

--- a/KronorComponents/MobilePay/MobilePayComponent.swift
+++ b/KronorComponents/MobilePay/MobilePayComponent.swift
@@ -15,7 +15,7 @@ public struct MobilePayComponent: View {
                 sessionToken: String,
                 returnURL: URL,
                 device: Kronor.Device? = nil,
-                onPaymentFailure: @escaping () -> (),
+                onPaymentFailure: @escaping (_ reason: FailureReason) -> (),
                 onPaymentSuccess: @escaping (_ paymentId: String) -> ()
     ) {
         let machine = EmbeddedPaymentStatechart.makeStateMachine()
@@ -58,8 +58,8 @@ struct MobilePayComponent_Previews: PreviewProvider {
             env: Preview.env,
             sessionToken: Preview.token,
             returnURL: Preview.returnURL,
-            onPaymentFailure: {
-                print("failed!")
+            onPaymentFailure: { reason in
+                print("failed: \(reason)")
             }
         ) { paymentId in
             print("done: \(paymentId)")

--- a/KronorComponents/PayPal/PayPalComponent.swift
+++ b/KronorComponents/PayPal/PayPalComponent.swift
@@ -15,7 +15,7 @@ public struct PayPalComponent: View {
                 sessionToken: String,
                 returnURL: URL,
                 device: Kronor.Device? = nil,
-                onPaymentFailure: @escaping () -> (),
+                onPaymentFailure: @escaping (_ reason: FailureReason) -> (),
                 onPaymentSuccess: @escaping (_ paymentId: String) -> ()
     ) {
         let machine = EmbeddedPaymentStatechart.makeStateMachine()
@@ -59,8 +59,8 @@ struct PayPalComponent_Previews: PreviewProvider {
             env: Preview.env,
             sessionToken: Preview.token,
             returnURL: Preview.returnURL,
-            onPaymentFailure: {
-                print("failed!")
+            onPaymentFailure: { reason in
+                print("failed: \(reason)")
             }
         ) { paymentId in
             print("done: \(paymentId)")

--- a/KronorComponents/Swish/SwishComponent.swift
+++ b/KronorComponents/Swish/SwishComponent.swift
@@ -15,7 +15,7 @@ public struct SwishComponent: View {
                 sessionToken: String,
                 returnURL: URL,
                 device: Kronor.Device? = nil,
-                onPaymentFailure: @escaping () -> (),
+                onPaymentFailure: @escaping (_ reason: FailureReason) -> (),
                 onPaymentSuccess: @escaping (_ paymentId: String) -> ()
     ) {
         let machine = SwishStatechart.makeStateMachine()
@@ -45,8 +45,8 @@ struct SwishComponent_Previews: PreviewProvider {
             env: Preview.env,
             sessionToken: Preview.token,
             returnURL: Preview.returnURL,
-            onPaymentFailure: {
-                print("failed!")
+            onPaymentFailure: { reason in
+                print("failed: \(reason)")
             }
         ) { paymentId in
             print("done: \(paymentId)")

--- a/KronorComponents/Swish/SwishStatechart.swift
+++ b/KronorComponents/Swish/SwishStatechart.swift
@@ -41,12 +41,12 @@ final class SwishStatechart : StateMachineBuilder {
     enum SideEffect {
         case createEcomPaymentRequest (phoneNumber: String)
         case createMcomPaymentRequest
-        case cancelPaymentRequest
         case openSwishApp
         case subscribeToPaymentStatus (waitToken: String)
         case notifyPaymentSuccess
         case notifyPaymentFailure
         case resetState
+        case cancelFlow
     }
     
     enum SelectedMethod : Equatable {
@@ -156,7 +156,7 @@ final class SwishStatechart : StateMachineBuilder {
             
             state(.paymentRejected) {
                 on(.cancelFlow) {
-                    dontTransition(emit: .notifyPaymentFailure)
+                    dontTransition(emit: .cancelFlow)
                 }
                 
                 on(.retry) {

--- a/KronorComponents/Vipps/VippsComponent.swift
+++ b/KronorComponents/Vipps/VippsComponent.swift
@@ -15,7 +15,7 @@ public struct VippsComponent: View {
                 sessionToken: String,
                 returnURL: URL,
                 device: Kronor.Device? = nil,
-                onPaymentFailure: @escaping () -> (),
+                onPaymentFailure: @escaping (_ reason: FailureReason) -> (),
                 onPaymentSuccess: @escaping (_ paymentId: String) -> ()
     ) {
         let machine = EmbeddedPaymentStatechart.makeStateMachine()
@@ -58,8 +58,8 @@ struct VippsComponent_Previews: PreviewProvider {
             env: Preview.env,
             sessionToken: Preview.token,
             returnURL: Preview.returnURL,
-            onPaymentFailure: {
-                print("failed!")
+            onPaymentFailure: { reason in
+                print("failed: \(reason)")
             }
         ) { paymentId in
             print("done: \(paymentId)")


### PR DESCRIPTION
this is a breaking change and requires clients of this library to add a new parameter to their `onFailure` callback.