### PR TITLE
Adjust how device info is handled

### DIFF
--- a/Kronor/Kronor/Device.swift
+++ b/Kronor/Kronor/Device.swift
@@ -13,7 +13,7 @@ let  fingerprinter = FingerprinterFactory.getInstance()
 
 public extension Kronor {
     
-    struct Device {
+    struct Device: Sendable {
         public var fingerprint: String
         public var appName: String
         public var appVersion: String

--- a/KronorComponents/BankTransfer/BankTransferComponent.swift
+++ b/KronorComponents/BankTransfer/BankTransferComponent.swift
@@ -21,7 +21,8 @@ public struct BankTransferComponent: View {
         let machine = EmbeddedPaymentStatechart.makeStateMachine()
         let networking = KronorEmbeddedPaymentNetworking(
             env: env,
-            token: sessionToken
+            token: sessionToken,
+            device: device
         )
         let viewModel = EmbeddedPaymentViewModel(
             env: env,
@@ -30,7 +31,6 @@ public struct BankTransferComponent: View {
             networking: networking,
             paymentMethod: .bankTransfer,
             returnURL: returnURL,
-            device: device,
             onPaymentFailure: onPaymentFailure,
             onPaymentSuccess: onPaymentSuccess
         )

--- a/KronorComponents/Common/Device+Extension.swift
+++ b/KronorComponents/Common/Device+Extension.swift
@@ -1,0 +1,22 @@
+//
+//  Device+Extension.swift
+//  Kronor
+//
+//  Created by Niclas Heltoft on 15/02/2025.
+//
+
+import Kronor
+import KronorApi
+
+extension Kronor.Device {
+    var deviceInfo: KronorApi.AddSessionDeviceInformationInput {
+        .init(
+            browserName: appName,
+            browserVersion: appVersion,
+            fingerprint: fingerprint,
+            osName: osName,
+            osVersion: osVersion,
+            userAgent: "\(appName)/\(appVersion) (\(deviceModel))"
+        )
+    }
+}

--- a/KronorComponents/Common/EmbeddedPaymentNetworking.swift
+++ b/KronorComponents/Common/EmbeddedPaymentNetworking.swift
@@ -11,23 +11,19 @@ import KronorApi
 
 protocol EmbeddedPaymentNetworking: PaymentNetworking {
     func createMobilePayPaymentRequest(
-        returnURL: URL,
-        device: Kronor.Device?
+        returnURL: URL
     ) async -> Result<String, KronorApi.KronorError>
 
     func createCreditCardPaymentRequest(
-        returnURL: URL,
-        device: Kronor.Device?
+        returnURL: URL
     ) async -> Result<String, KronorApi.KronorError>
     
     func createVippsRequest(
-        returnURL: URL,
-        device: Kronor.Device?
+        returnURL: URL
     ) async -> Result<String, KronorApi.KronorError>
     
     func createPayPalRequest(
         returnURL: URL,
-        merchantReturnURL: URL,
-        device: Kronor.Device?
+        merchantReturnURL: URL
     ) async -> Result<String, KronorApi.KronorError>
 }

--- a/KronorComponents/Common/EmbeddedPaymentViewModel.swift
+++ b/KronorComponents/Common/EmbeddedPaymentViewModel.swift
@@ -60,7 +60,6 @@ class EmbeddedPaymentViewModel: ObservableObject {
     private var subscription: Cancellable?
 
     private var paymentMethod: SupportedEmbeddedMethod
-    private var device: Kronor.Device?
     private var onPaymentFailure: (_ reason: FailureReason) -> ()
     private var onPaymentSuccess: (_ paymentId: String) -> ()
     internal let sessionURL: URL
@@ -76,14 +75,12 @@ class EmbeddedPaymentViewModel: ObservableObject {
          networking: some EmbeddedPaymentNetworking,
          paymentMethod: SupportedEmbeddedMethod,
          returnURL: URL,
-         device: Kronor.Device? = nil,
          onPaymentFailure: @escaping (_ reason: FailureReason) -> (),
          onPaymentSuccess: @escaping (_ paymentId: String) -> ()
     ) {
         self.stateMachine = stateMachine
         self.networking = networking
         self.state = stateMachine.state
-        self.device = device
         self.onPaymentSuccess = onPaymentSuccess
         self.onPaymentFailure = onPaymentFailure
         self.paymentMethod = paymentMethod
@@ -148,24 +145,20 @@ class EmbeddedPaymentViewModel: ObservableObject {
                 switch self.paymentMethod {
                 case .mobilePay:
                     return await networking.createMobilePayPaymentRequest(
-                        returnURL: self.returnURL,
-                        device: self.device
+                        returnURL: self.returnURL
                     )
                 case .creditCard:
                     return await networking.createCreditCardPaymentRequest(
-                        returnURL: self.returnURL,
-                        device: self.device
+                        returnURL: self.returnURL
                     )
                 case .vipps:
                     return await networking.createVippsRequest(
-                        returnURL: self.returnURL,
-                        device: self.device
+                        returnURL: self.returnURL
                     )
                 case .payPal:
                     return await networking.createPayPalRequest(
                         returnURL: self.intermediateRedirectURL,
-                        merchantReturnURL: self.returnURL,
-                        device: self.device
+                        merchantReturnURL: self.returnURL
                     )
                 case .bankTransfer, .p24, .fallback:
                     // cannot create the payment request as we don't know how.

--- a/KronorComponents/Common/KronorEmbeddedPaymentNetworking.swift
+++ b/KronorComponents/Common/KronorEmbeddedPaymentNetworking.swift
@@ -12,75 +12,53 @@ import Apollo
 
 final class KronorEmbeddedPaymentNetworking: KronorPaymentNetworking, EmbeddedPaymentNetworking {
     func createMobilePayPaymentRequest(
-        returnURL: URL,
-        device: Kronor.Device?
+        returnURL: URL
     ) async -> Result<String, KronorApi.KronorError> {
         let input = KronorApi.MobilePayPaymentInput(
             idempotencyKey: UUID().uuidString,
             returnUrl: returnURL.absoluteString
         )
 
-        var deviceInfo = device.map(makeDeviceInfo)
-        if deviceInfo == nil {
-            let def = await Kronor.detectDevice()
-            deviceInfo = makeDeviceInfo(device: def)
-        }
-
         return await KronorApi.createMobilePayPaymentRequest(
             client: client,
             input: input,
-            deviceInfo: deviceInfo!
+            deviceInfo: deviceInfo
         )
     }
 
     func createCreditCardPaymentRequest(
-        returnURL: URL,
-        device: Kronor.Device?
+        returnURL: URL
     ) async -> Result<String, KronorApi.KronorError> {
         let input = KronorApi.CreditCardPaymentInput(
             idempotencyKey: UUID().uuidString,
             returnUrl: returnURL.absoluteString
         )
 
-        var deviceInfo = device.map(makeDeviceInfo)
-        if deviceInfo == nil {
-            let def = await Kronor.detectDevice()
-            deviceInfo = makeDeviceInfo(device: def)
-        }
-
         return await KronorApi.createCreditCardPaymentRequest(
             client: client,
             input: input,
-            deviceInfo: deviceInfo!
+            deviceInfo: deviceInfo
         )
     }
 
     func createVippsRequest(
-        returnURL: URL,
-        device: Kronor.Device?
+        returnURL: URL
     ) async -> Result<String, KronorApi.KronorError> {
         let input = KronorApi.VippsPaymentInput(
             idempotencyKey: UUID().uuidString,
             returnUrl: returnURL.absoluteString
         )
 
-        var deviceInfo = device.map(makeDeviceInfo)
-        if deviceInfo == nil {
-            let def = await Kronor.detectDevice()
-            deviceInfo = makeDeviceInfo(device: def)
-        }
-
         return await KronorApi.createVippsPaymentRequest(
             client: client,
             input: input,
-            deviceInfo: deviceInfo!
+            deviceInfo: deviceInfo
         )
     }
 
     func createPayPalRequest(
         returnURL: URL,
-        merchantReturnURL: URL,
-        device: Kronor.Device?
+        merchantReturnURL: URL
     ) async -> Result<String, KronorApi.KronorError> {
          let input = KronorApi.PayPalPaymentInput(
              idempotencyKey: UUID().uuidString,
@@ -88,12 +66,10 @@ final class KronorEmbeddedPaymentNetworking: KronorPaymentNetworking, EmbeddedPa
              returnUrl: returnURL.absoluteString
          )
 
-         var deviceInfo = device.map(makeDeviceInfo)
-         if deviceInfo == nil {
-             let def = await Kronor.detectDevice()
-             deviceInfo = makeDeviceInfo(device: def)
-         }
-
-         return await KronorApi.createPayPalPaymentRequest(client: client, input: input, deviceInfo: deviceInfo!)
+         return await KronorApi.createPayPalPaymentRequest(
+            client: client,
+            input: input,
+            deviceInfo: deviceInfo
+         )
      }
 }

--- a/KronorComponents/Common/KronorPaymentNetworking.swift
+++ b/KronorComponents/Common/KronorPaymentNetworking.swift
@@ -11,16 +11,42 @@ import KronorApi
 import Kronor
 
 class KronorPaymentNetworking: PaymentNetworking {
+    private actor State {
+        var device: Kronor.Device?
+
+        init(device: Kronor.Device?) {
+            self.device = device
+        }
+
+        func setDevice(_ device: Kronor.Device?) {
+            self.device = device
+        }
+    }
+
+    private let state: State
     let client: ApolloClient
+    var deviceInfo: KronorApi.AddSessionDeviceInformationInput {
+        get async {
+            if let device = await state.device {
+                return device.deviceInfo
+            }
+
+            let device = await Kronor.detectDevice()
+            await state.setDevice(device)
+            return device.deviceInfo
+        }
+    }
 
     init(
         env: Kronor.Environment,
-        token: String
+        token: String,
+        device: Kronor.Device?
     ) {
         self.client = KronorApi.makeGraphQLClient(
             env: env,
             token: token
         )
+        self.state = .init(device: device)
     }
 
     func subscribeToPaymentStatus(

--- a/KronorComponents/Common/Preview.swift
+++ b/KronorComponents/Common/Preview.swift
@@ -13,6 +13,7 @@ enum Preview {
     static let env = Kronor.Environment.sandbox
     static let token = "dummy"
     static let returnURL = URL(string: "io.kronortest://")!
+    static let device: Kronor.Device? = nil
 
     static func makeEmbeddedPaymentViewModel(
         paymentMethod: SupportedEmbeddedMethod,
@@ -26,7 +27,8 @@ enum Preview {
         }
         let networking = KronorEmbeddedPaymentNetworking(
             env: env,
-            token: token
+            token: token,
+            device: device
         )
         return EmbeddedPaymentViewModel(
             env: env,
@@ -51,7 +53,8 @@ enum Preview {
         }
         let networking = KronorSwishPaymentNetworking(
             env: env,
-            token: token
+            token: token,
+            device: device
         )
         return SwishPaymentViewModel(
             stateMachine: machine,

--- a/KronorComponents/CreditCard/CreditCardComponent.swift
+++ b/KronorComponents/CreditCard/CreditCardComponent.swift
@@ -21,7 +21,8 @@ public struct CreditCardComponent: View {
         let machine = EmbeddedPaymentStatechart.makeStateMachine()
         let networking = KronorEmbeddedPaymentNetworking(
             env: env,
-            token: sessionToken
+            token: sessionToken,
+            device: device
         )
         let viewModel = EmbeddedPaymentViewModel(
             env: env,
@@ -30,7 +31,6 @@ public struct CreditCardComponent: View {
             networking: networking,
             paymentMethod: .creditCard,
             returnURL: returnURL,
-            device: device,
             onPaymentFailure: onPaymentFailure,
             onPaymentSuccess: onPaymentSuccess
         )

--- a/KronorComponents/Fallback/FallbackComponent.swift
+++ b/KronorComponents/Fallback/FallbackComponent.swift
@@ -22,7 +22,8 @@ public struct FallbackComponent: View {
         let machine = EmbeddedPaymentStatechart.makeStateMachine()
         let networking = KronorEmbeddedPaymentNetworking(
             env: env,
-            token: sessionToken
+            token: sessionToken,
+            device: device
         )
         let viewModel = EmbeddedPaymentViewModel(
             env: env,
@@ -31,7 +32,6 @@ public struct FallbackComponent: View {
             networking: networking,
             paymentMethod: .fallback(name: paymentMethodName),
             returnURL: returnURL,
-            device: device,
             onPaymentFailure: onPaymentFailure,
             onPaymentSuccess: onPaymentSuccess
         )

--- a/KronorComponents/MobilePay/MobilePayComponent.swift
+++ b/KronorComponents/MobilePay/MobilePayComponent.swift
@@ -21,7 +21,8 @@ public struct MobilePayComponent: View {
         let machine = EmbeddedPaymentStatechart.makeStateMachine()
         let networking = KronorEmbeddedPaymentNetworking(
             env: env,
-            token: sessionToken
+            token: sessionToken,
+            device: device
         )
         let viewModel = EmbeddedPaymentViewModel(
             env: env,
@@ -30,7 +31,6 @@ public struct MobilePayComponent: View {
             networking: networking,
             paymentMethod: .mobilePay,
             returnURL: returnURL,
-            device: device,
             onPaymentFailure: onPaymentFailure,
             onPaymentSuccess: onPaymentSuccess
         )

--- a/KronorComponents/P24/P24Component.swift
+++ b/KronorComponents/P24/P24Component.swift
@@ -21,7 +21,8 @@ public struct P24Component: View {
         let machine = EmbeddedPaymentStatechart.makeStateMachine()
         let networking = KronorEmbeddedPaymentNetworking(
             env: env,
-            token: sessionToken
+            token: sessionToken,
+            device: device
         )
         let viewModel = EmbeddedPaymentViewModel(
             env: env,
@@ -30,7 +31,6 @@ public struct P24Component: View {
             networking: networking,
             paymentMethod: .p24,
             returnURL: returnURL,
-            device: device,
             onPaymentFailure: onPaymentFailure,
             onPaymentSuccess: onPaymentSuccess
         )

--- a/KronorComponents/PayPal/PayPalComponent.swift
+++ b/KronorComponents/PayPal/PayPalComponent.swift
@@ -21,7 +21,8 @@ public struct PayPalComponent: View {
         let machine = EmbeddedPaymentStatechart.makeStateMachine()
         let networking = KronorEmbeddedPaymentNetworking(
             env: env,
-            token: sessionToken
+            token: sessionToken,
+            device: device
         )
 
         let viewModel = EmbeddedPaymentViewModel(
@@ -31,7 +32,6 @@ public struct PayPalComponent: View {
             networking: networking,
             paymentMethod: .payPal,
             returnURL: returnURL,
-            device: device,
             onPaymentFailure: onPaymentFailure,
             onPaymentSuccess: onPaymentSuccess
         )

--- a/KronorComponents/Swish/KronorSwishPaymentNetworking.swift
+++ b/KronorComponents/Swish/KronorSwishPaymentNetworking.swift
@@ -11,8 +11,7 @@ import KronorApi
 
 final class KronorSwishPaymentNetworking: KronorPaymentNetworking, SwishPaymentNetworking {
     func createMcomPaymentRequest(
-        returnURL: URL,
-        device: Kronor.Device?
+        returnURL: URL
     ) async -> Result<String, KronorApi.KronorError> {
         let input = KronorApi.SwishPaymentInput(
             flow: "mcom",
@@ -20,23 +19,16 @@ final class KronorSwishPaymentNetworking: KronorPaymentNetworking, SwishPaymentN
             returnUrl: returnURL.absoluteString
         )
 
-        var deviceInfo = device.map(makeDeviceInfo)
-        if deviceInfo == nil {
-            let def = await Kronor.detectDevice()
-            deviceInfo = makeDeviceInfo(device: def)
-        }
-
         return await KronorApi.createSwishPaymentRequest(
             client: client,
             input: input,
-            deviceInfo: deviceInfo!
+            deviceInfo: deviceInfo
         )
     }
 
     func createEcomPaymentRequest(
         phoneNumber: String,
-        returnURL: URL,
-        device: Kronor.Device?
+        returnURL: URL
     ) async -> Result<String, KronorApi.KronorError> {
         let input = KronorApi.SwishPaymentInput(
             customerSwishNumber: .some(phoneNumber),
@@ -45,16 +37,10 @@ final class KronorSwishPaymentNetworking: KronorPaymentNetworking, SwishPaymentN
             returnUrl: returnURL.absoluteString
         )
 
-        var deviceInfo = device.map(makeDeviceInfo)
-        if deviceInfo == nil {
-            let def = await Kronor.detectDevice()
-            deviceInfo = makeDeviceInfo(device: def)
-        }
-
         return await KronorApi.createSwishPaymentRequest(
             client: client,
             input: input,
-            deviceInfo: deviceInfo!
+            deviceInfo: deviceInfo
         )
     }
 }

--- a/KronorComponents/Swish/SwishComponent.swift
+++ b/KronorComponents/Swish/SwishComponent.swift
@@ -21,13 +21,13 @@ public struct SwishComponent: View {
         let machine = SwishStatechart.makeStateMachine()
         let networking = KronorSwishPaymentNetworking(
             env: env,
-            token: sessionToken
+            token: sessionToken,
+            device: device
         )
         self.viewModel = SwishPaymentViewModel(
             stateMachine: machine,
             networking: networking,
             returnURL: returnURL,
-            device: device,
             onPaymentFailure: onPaymentFailure,
             onPaymentSuccess: onPaymentSuccess
         )

--- a/KronorComponents/Swish/SwishPaymentNetworking.swift
+++ b/KronorComponents/Swish/SwishPaymentNetworking.swift
@@ -11,13 +11,11 @@ import KronorApi
 
 protocol SwishPaymentNetworking: PaymentNetworking {
     func createMcomPaymentRequest(
-        returnURL: URL,
-        device: Kronor.Device?
+        returnURL: URL
     ) async -> Result<String, KronorApi.KronorError>
 
     func createEcomPaymentRequest(
         phoneNumber: String,
-        returnURL: URL,
-        device: Kronor.Device?
+        returnURL: URL
     ) async -> Result<String, KronorApi.KronorError>
 }

--- a/KronorComponents/Swish/SwishPaymentViewModel.swift
+++ b/KronorComponents/Swish/SwishPaymentViewModel.swift
@@ -41,7 +41,6 @@ class SwishPaymentViewModel: ObservableObject {
     }
     
     private var returnURL: URL
-    private var device: Kronor.Device?
     private var onPaymentFailure: (_ reason: FailureReason) -> ()
     private var onPaymentSuccess: (_ paymentId: String) -> ()
     
@@ -57,7 +56,6 @@ class SwishPaymentViewModel: ObservableObject {
         stateMachine: SwishStatechart.SwishStateMachine,
         networking: some SwishPaymentNetworking,
         returnURL: URL,
-        device: Kronor.Device? = nil,
         onPaymentFailure: @escaping (_ reason: FailureReason) -> (),
         onPaymentSuccess: @escaping (_ paymentId: String) -> ()
     ) {
@@ -65,7 +63,6 @@ class SwishPaymentViewModel: ObservableObject {
         self.networking = networking
         self.state = stateMachine.state
         self.returnURL = returnURL
-        self.device = device
         self.onPaymentSuccess = onPaymentSuccess
         self.onPaymentFailure = onPaymentFailure
     }
@@ -98,8 +95,7 @@ class SwishPaymentViewModel: ObservableObject {
             Self.logger.debug("creating swish mcom request")
 
             let rWaitToken = await networking.createMcomPaymentRequest(
-                returnURL: self.returnURL,
-                device: self.device
+                returnURL: self.returnURL
             )
             
             switch rWaitToken {
@@ -116,8 +112,7 @@ class SwishPaymentViewModel: ObservableObject {
             Self.logger.debug("creating swish ecom request")
             let rWaitToken = await networking.createEcomPaymentRequest(
                 phoneNumber: phoneNumber,
-                returnURL: self.returnURL,
-                device: self.device
+                returnURL: self.returnURL
             )
             
             switch rWaitToken {
@@ -289,15 +284,4 @@ extension SwishPaymentViewModel: RetryableModel {
             await self.transition(.retry)
         }
     }
-}
-
-func makeDeviceInfo(device: Kronor.Device) -> KronorApi.AddSessionDeviceInformationInput {
-    KronorApi.AddSessionDeviceInformationInput(
-        browserName: device.appName,
-        browserVersion: device.appVersion,
-        fingerprint: device.fingerprint,
-        osName: device.osName,
-        osVersion: device.osVersion,
-        userAgent: "\(device.appName)/\(device.appVersion) (\(device.deviceModel))"
-    )
 }

--- a/KronorComponents/Vipps/VippsComponent.swift
+++ b/KronorComponents/Vipps/VippsComponent.swift
@@ -21,7 +21,8 @@ public struct VippsComponent: View {
         let machine = EmbeddedPaymentStatechart.makeStateMachine()
         let networking = KronorEmbeddedPaymentNetworking(
             env: env,
-            token: sessionToken
+            token: sessionToken,
+            device: device
         )
         let viewModel = EmbeddedPaymentViewModel(
             env: env,
@@ -30,7 +31,6 @@ public struct VippsComponent: View {
             networking: networking,
             paymentMethod: .vipps,
             returnURL: returnURL,
-            device: device,
             onPaymentFailure: onPaymentFailure,
             onPaymentSuccess: onPaymentSuccess
         )


### PR DESCRIPTION
This change moves the device out of the view model and handles it in the networking layer instead.

This allows us to remove the global device function and simplify networking in the view model. 
Furthermore this allows the device detection to be done once and the result stored instead of previously where the device would be recomputed every time a network call was made.