### PR TITLE
Fix crashes related to websockets

### DIFF
--- a/KronorApi/Client.swift
+++ b/KronorApi/Client.swift
@@ -42,7 +42,7 @@ public extension KronorApi {
     }
     
     static func makeGraphQLClient(env: Kronor.Environment, token: String) -> ApolloClient {
-        let webSocketClient = WebSocket(url: env.websocketURL, protocol: .graphql_ws)
+        let webSocketClient = URLSessionWebSocket(url: env.websocketURL, protocol: .graphql_ws)
         let payload: JSONEncodableDictionary = ["headers": ["Authorization": "Bearer " + token]]
         let wsConfig = WebSocketTransport.Configuration(reconnect:true, connectingPayload: payload)
         let webSocketTransport = WebSocketTransport(websocket: webSocketClient, store: store, config: wsConfig)

--- a/Package.resolved
+++ b/Package.resolved
@@ -3,25 +3,25 @@
     {
       "identity" : "apollo-ios",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apollographql/apollo-ios.git",
+      "location" : "git@github.com:portolans/apollo-ios.git",
       "state" : {
-        "revision" : "6ecc75281dab2fa231cb0d5fed3a3713826fecae",
-        "version" : "1.21.0"
+        "branch" : "release--1.23.0",
+        "revision" : "ac25139dcc6db72d18182069e91694c027d82b6f"
       }
     },
     {
       "identity" : "fingerprintjs-ios",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/fingerprintjs/fingerprintjs-ios",
+      "location" : "git@github.com:fingerprintjs/fingerprintjs-ios.git",
       "state" : {
-        "revision" : "b34f55f1c527dc6122a402531ee7d52c61c422a2",
-        "version" : "1.4.0"
+        "revision" : "2e2ead3d02c46736d9b4a66373700489113e293a",
+        "version" : "1.6.0"
       }
     },
     {
       "identity" : "statemachine",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Tinder/StateMachine",
+      "location" : "git@github.com:Tinder/StateMachine.git",
       "state" : {
         "revision" : "0f7964206bd8dbc70f5a30fed0b1db76bfcc1b24",
         "version" : "0.3.0"
@@ -30,7 +30,7 @@
     {
       "identity" : "trustlyiossdk",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/trustly/TrustlyIosSdk",
+      "location" : "git@github.com:trustly/TrustlyIosSdk.git",
       "state" : {
         "revision" : "2ee7e7d2e9dff110415b369da3bcd3af24e8c368",
         "version" : "4.0.1"

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -7,7 +7,7 @@ let package = Package(
     name: "Kronor",
     defaultLocalization: "en",
     platforms: [
-      .iOS(.v15),
+        .iOS(.v17),
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
@@ -29,19 +29,19 @@ let package = Package(
     ],
     dependencies: [
         .package(
-            url: "https://github.com/apollographql/apollo-ios.git",
-            .upToNextMinor(from: "1.21.0")
+            url: "git@github.com:portolans/apollo-ios.git",
+            branch: "release--1.23.0"
         ),
         .package(
-            url: "https://github.com/Tinder/StateMachine",
+            url: "git@github.com:Tinder/StateMachine.git",
             .upToNextMajor(from: "0.3.0")
         ),
         .package(
-            url: "https://github.com/fingerprintjs/fingerprintjs-ios",
+            url: "git@github.com:fingerprintjs/fingerprintjs-ios.git",
             .upToNextMajor(from: "1.0.0")
         ),
         .package(
-            url: "https://github.com/trustly/TrustlyIosSdk",
+            url: "git@github.com:trustly/TrustlyIosSdk.git",
             .upToNextMajor(from: "4.0.1")
         ),
     ],


### PR DESCRIPTION
It was reported that using websockets is a common source of crashes in Kronor. This commit includes a new implementation of the websocket client, via a fork of the apollo-ios library. This implementation is more robust and stable, and should eliminate the crashes related to websockets. The company behind the fork has proven it to work without crashes in production.