### PR TITLE
Allow consumers to toggle websockets on/off

### DIFF
--- a/KronorComponents/Common/ComponentConfiguration.swift
+++ b/KronorComponents/Common/ComponentConfiguration.swift
@@ -18,8 +18,8 @@ public struct ComponentConfiguration {
     public let returnURL: URL
     /// Optional device information for device-specific payment flows.
     public let device: Kronor.Device?
-    /// Whether or not websockets is used for payment status updates.
-    public let isWebsocketsEnabled: Bool
+    /// Whether WebSockets are used for payment status updates.
+    public let isWebSocketsEnabled: Bool
 
     /// Creates a new component configuration.
     /// - Parameters:
@@ -27,18 +27,18 @@ public struct ComponentConfiguration {
     ///   - sessionToken: The session token obtained from the backend.
     ///   - returnURL: The URL to redirect back to after the payment flow.
     ///   - device: Optional device information. Defaults to `nil`.
-    ///   - isWebsocketsEnabled: Whether or not websockets is used for payment status updates. Defaults to `true`.
+    ///   - isWebSocketsEnabled: Whether WebSockets are used for payment status updates. Defaults to `true`.
     public init(
         env: Kronor.Environment,
         sessionToken: String,
         returnURL: URL,
         device: Kronor.Device? = nil,
-        isWebsocketsEnabled: Bool = true
+        isWebSocketsEnabled: Bool = true
     ) {
         self.env = env
         self.sessionToken = sessionToken
         self.returnURL = returnURL
         self.device = device
-        self.isWebsocketsEnabled = isWebsocketsEnabled
+        self.isWebSocketsEnabled = isWebSocketsEnabled
     }
 }

--- a/KronorComponents/Common/ComponentConfiguration.swift
+++ b/KronorComponents/Common/ComponentConfiguration.swift
@@ -18,6 +18,8 @@ public struct ComponentConfiguration {
     public let returnURL: URL
     /// Optional device information for device-specific payment flows.
     public let device: Kronor.Device?
+    /// Whether or not websockets is used for payment status updates.
+    public let isWebsocketsEnabled: Bool
 
     /// Creates a new component configuration.
     /// - Parameters:
@@ -25,15 +27,18 @@ public struct ComponentConfiguration {
     ///   - sessionToken: The session token obtained from the backend.
     ///   - returnURL: The URL to redirect back to after the payment flow.
     ///   - device: Optional device information. Defaults to `nil`.
+    ///   - isWebsocketsEnabled: Whether or not websockets is used for payment status updates. Defaults to `true`.
     public init(
         env: Kronor.Environment,
         sessionToken: String,
         returnURL: URL,
-        device: Kronor.Device? = nil
+        device: Kronor.Device? = nil,
+        isWebsocketsEnabled: Bool = true
     ) {
         self.env = env
         self.sessionToken = sessionToken
         self.returnURL = returnURL
         self.device = device
+        self.isWebsocketsEnabled = isWebsocketsEnabled
     }
 }

--- a/KronorComponents/Common/KronorPaymentNetworking.swift
+++ b/KronorComponents/Common/KronorPaymentNetworking.swift
@@ -29,6 +29,7 @@ class KronorPaymentNetworking: PaymentNetworking {
     let client: ApolloClient
     let pollingManager: PollingManager
     let env: Kronor.Environment
+    let isWebsocketsEnabled: Bool
 
     var deviceInfo: KronorApi.AddSessionDeviceInformationInput {
         get async {
@@ -48,13 +49,43 @@ class KronorPaymentNetworking: PaymentNetworking {
             env: configuration.env,
             token: configuration.sessionToken
         )
-
+        self.isWebsocketsEnabled = configuration.isWebsocketsEnabled
         self.pollingManager = PollingManager(pollingInterval: 1)
-
         self.state = .init(device: configuration.device)
     }
 
-    func establishWebSocketConnection() async throws -> NWConnection {
+    func subscribeToPaymentStatus(
+        resultHandler: @escaping (Result<KronorApi.PaymentStatusSubscription.Data, Error>, KronorApi.APIError?) -> Void
+    ) async -> Cancellable {
+        if isWebsocketsEnabled {
+            do {
+                return try await websocketPaymentStatusSubscription(resultHandler: resultHandler)
+            } catch {
+                return await pollingPaymentStatusSubscription(resultHandler: resultHandler)
+            }
+        } else {
+            return await pollingPaymentStatusSubscription(resultHandler: resultHandler)
+        }
+    }
+
+    func cancelSessionPayments() async -> Result<(), Never> {
+        await withCheckedContinuation { continuation in
+            client.perform(
+                mutation: KronorApi.CancelSessionPaymentsMutation(
+                    idempotencyKey: UUID().uuidString
+                )
+            ) { data in
+                continuation.resume(
+                    returning: .success(())
+                )
+            }
+        }
+    }
+}
+
+// MARK: - Helpers
+extension KronorPaymentNetworking {
+    private func establishWebSocketConnection() async throws -> NWConnection {
         let tcpOptions: NWProtocolTCP.Options = {
             let options = NWProtocolTCP.Options()
             options.connectionTimeout = 5
@@ -85,76 +116,64 @@ class KronorPaymentNetworking: PaymentNetworking {
                     connection.stateUpdateHandler = nil
                     continuation.resume(throwing: error)
                 default:
-                   break
-               }
-           }
-
-           connection.start(queue: .main)
-        }
-    }
-
-    func subscribeToPaymentStatus(
-        resultHandler: @escaping (Result<KronorApi.PaymentStatusSubscription.Data, Error>, KronorApi.APIError?) -> Void
-    ) async -> Cancellable {
-        do {
-            try await self.establishWebSocketConnection()
-            return client.subscribe(
-                subscription: KronorApi.PaymentStatusSubscription(),
-                resultHandler: { result in
-                    resultHandler(
-                        result.flatMap({ graphQLData in
-                            switch graphQLData.data {
-                            case .some(let data):
-                                return .success(data)
-                            case .none:
-                                return .failure(
-                                    KronorApi.APIError(
-                                        errors: [],
-                                        extensions: [:]
-                                    )
-                                )
-                            }
-                        }),
-                        nil
-                    )
-                }
-            )
-        } catch {
-            return self.pollingManager.startPolling {
-                self.client.fetch(query: KronorApi.PaymentStatusQuery(), cachePolicy: .fetchIgnoringCacheCompletely) { result in
-                    resultHandler(
-                        result.flatMap({ graphQLData in
-                            switch graphQLData.data {
-                            case .some(let data):
-                                return .success(KronorApi.PaymentStatusSubscription.Data(_dataDict: data.__data))
-                            case .none:
-                                return .failure(
-                                    KronorApi.APIError(
-                                        errors: [],
-                                        extensions: [:]
-                                    )
-                                )
-                            }
-                        }),
-                        KronorApi.APIError(
-                            errors: (try? result.get().errors) ?? [],
-                            extensions: (try? result.get().extensions) ?? [:]
-                        )
-                    )
+                    break
                 }
             }
+
+            connection.start(queue: .main)
         }
     }
 
-    func cancelSessionPayments() async -> Result<(), Never> {
-        await withCheckedContinuation { continuation in
-            client.perform(
-                mutation: KronorApi.CancelSessionPaymentsMutation(
-                    idempotencyKey: UUID().uuidString
+    private func websocketPaymentStatusSubscription(
+        resultHandler: @escaping (Result<KronorApi.PaymentStatusSubscription.Data, Error>, KronorApi.APIError?) -> Void
+    ) async throws -> Cancellable {
+        _ = try await establishWebSocketConnection()
+        return client.subscribe(
+            subscription: KronorApi.PaymentStatusSubscription(),
+            resultHandler: { result in
+                resultHandler(
+                    result.flatMap({ graphQLData in
+                        switch graphQLData.data {
+                        case .some(let data):
+                            return .success(data)
+                        case .none:
+                            return .failure(
+                                KronorApi.APIError(
+                                    errors: [],
+                                    extensions: [:]
+                                )
+                            )
+                        }
+                    }),
+                    nil
                 )
-            ) { data in
-                continuation.resume(
-                    returning: .success(())
+            }
+        )
+    }
+
+    private func pollingPaymentStatusSubscription(
+        resultHandler: @escaping (Result<KronorApi.PaymentStatusSubscription.Data, Error>, KronorApi.APIError?) -> Void
+    ) async -> Cancellable {
+        pollingManager.startPolling {
+            self.client.fetch(query: KronorApi.PaymentStatusQuery(), cachePolicy: .fetchIgnoringCacheCompletely) { result in
+                resultHandler(
+                    result.flatMap({ graphQLData in
+                        switch graphQLData.data {
+                        case .some(let data):
+                            return .success(KronorApi.PaymentStatusSubscription.Data(_dataDict: data.__data))
+                        case .none:
+                            return .failure(
+                                KronorApi.APIError(
+                                    errors: [],
+                                    extensions: [:]
+                                )
+                            )
+                        }
+                    }),
+                    KronorApi.APIError(
+                        errors: (try? result.get().errors) ?? [],
+                        extensions: (try? result.get().extensions) ?? [:]
+                    )
                 )
             }
         }

--- a/KronorComponents/Common/KronorPaymentNetworking.swift
+++ b/KronorComponents/Common/KronorPaymentNetworking.swift
@@ -29,7 +29,7 @@ class KronorPaymentNetworking: PaymentNetworking {
     let client: ApolloClient
     let pollingManager: PollingManager
     let env: Kronor.Environment
-    let isWebsocketsEnabled: Bool
+    let isWebSocketsEnabled: Bool
 
     var deviceInfo: KronorApi.AddSessionDeviceInformationInput {
         get async {
@@ -49,7 +49,7 @@ class KronorPaymentNetworking: PaymentNetworking {
             env: configuration.env,
             token: configuration.sessionToken
         )
-        self.isWebsocketsEnabled = configuration.isWebsocketsEnabled
+        self.isWebSocketsEnabled = configuration.isWebSocketsEnabled
         self.pollingManager = PollingManager(pollingInterval: 1)
         self.state = .init(device: configuration.device)
     }
@@ -57,14 +57,14 @@ class KronorPaymentNetworking: PaymentNetworking {
     func subscribeToPaymentStatus(
         resultHandler: @escaping (Result<KronorApi.PaymentStatusSubscription.Data, Error>, KronorApi.APIError?) -> Void
     ) async -> Cancellable {
-        if isWebsocketsEnabled {
+        if isWebSocketsEnabled {
             do {
                 return try await websocketPaymentStatusSubscription(resultHandler: resultHandler)
             } catch {
-                return await pollingPaymentStatusSubscription(resultHandler: resultHandler)
+                return pollingPaymentStatusSubscription(resultHandler: resultHandler)
             }
         } else {
-            return await pollingPaymentStatusSubscription(resultHandler: resultHandler)
+            return pollingPaymentStatusSubscription(resultHandler: resultHandler)
         }
     }
 
@@ -153,7 +153,7 @@ extension KronorPaymentNetworking {
 
     private func pollingPaymentStatusSubscription(
         resultHandler: @escaping (Result<KronorApi.PaymentStatusSubscription.Data, Error>, KronorApi.APIError?) -> Void
-    ) async -> Cancellable {
+    ) -> Cancellable {
         pollingManager.startPolling {
             self.client.fetch(query: KronorApi.PaymentStatusQuery(), cachePolicy: .fetchIgnoringCacheCompletely) { result in
                 resultHandler(


### PR DESCRIPTION
The websockets in Apollo is currently not as stable as we would like them to be and can cause crashes in some scenarios. 

To remedy this the changes here introduces a way for consumers to control if websockets should be used for the subscriptions to payment status updates.

This is intended as a temporary solution until websockets is implemented in the next major version of Apollo and we have deemed it stable enough to remove this possibility again.  