### PR TITLE
EuroBonus Verification Fix (ASWebAuthenticationSession)

### DIFF
--- a/KronorComponents/Common/AuthSessionView.swift
+++ b/KronorComponents/Common/AuthSessionView.swift
@@ -1,0 +1,106 @@
+//
+//  AuthSessionView.swift
+//  KronorComponents
+//
+//  Created by Tim Kofoed on 23/03/2026.
+//
+
+import SwiftUI
+import AuthenticationServices
+
+struct AuthSessionViewRepresentable: UIViewControllerRepresentable {
+
+    typealias UIViewControllerType = AuthSessionViewController
+
+    private let url: URL
+    private let callbackScheme: String
+    private let onComplete: () -> Void
+    private let onCancel: () -> Void
+
+    init(
+        url: URL,
+        callbackScheme: String,
+        onComplete: @escaping () -> Void,
+        onCancel: @escaping () -> Void
+    ) {
+        self.url = url
+        self.callbackScheme = callbackScheme
+        self.onComplete = onComplete
+        self.onCancel = onCancel
+    }
+
+    func makeUIViewController(context: Context) -> AuthSessionViewController {
+        AuthSessionViewController(
+            url: url,
+            callbackScheme: callbackScheme,
+            onComplete: onComplete,
+            onCancel: onCancel
+        )
+    }
+
+    func updateUIViewController(_ uiViewController: AuthSessionViewController, context: Context) { }
+}
+
+final class AuthSessionViewController: UIViewController, ASWebAuthenticationPresentationContextProviding {
+
+    private let url: URL
+    private let callbackScheme: String
+    private let onComplete: () -> Void
+    private let onCancel: () -> Void
+    private var authSession: ASWebAuthenticationSession?
+    private var hasStarted = false
+
+    init(
+        url: URL,
+        callbackScheme: String,
+        onComplete: @escaping () -> Void,
+        onCancel: @escaping () -> Void
+    ) {
+        self.url = url
+        self.callbackScheme = callbackScheme
+        self.onComplete = onComplete
+        self.onCancel = onCancel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        guard !hasStarted else { return }
+        hasStarted = true
+        startAuthSession()
+    }
+
+    private func startAuthSession() {
+        let session = ASWebAuthenticationSession(
+            url: url,
+            callbackURLScheme: callbackScheme
+        ) { [onComplete, onCancel] _, error in
+            if let sessionError = error as? ASWebAuthenticationSessionError,
+               sessionError.code == .canceledLogin {
+                onCancel()
+                return
+            }
+
+            if error != nil {
+                onCancel()
+                return
+            }
+
+            onComplete()
+        }
+
+        session.prefersEphemeralWebBrowserSession = false
+        session.presentationContextProvider = self
+        authSession = session
+        session.start()
+    }
+
+    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        view.window ?? ASPresentationAnchor()
+    }
+}

--- a/KronorComponents/Common/AuthSessionView.swift
+++ b/KronorComponents/Common/AuthSessionView.swift
@@ -97,10 +97,14 @@ final class AuthSessionViewController: UIViewController, ASWebAuthenticationPres
         session.prefersEphemeralWebBrowserSession = false
         session.presentationContextProvider = self
         authSession = session
-        session.start()
+
+        let didStart = session.start()
+        if !didStart {
+            onCancel()
+        }
     }
 
     func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
-        view.window ?? ASPresentationAnchor()
+        view.window!
     }
 }

--- a/KronorComponents/Common/ComponentConfiguration.swift
+++ b/KronorComponents/Common/ComponentConfiguration.swift
@@ -20,6 +20,11 @@ public struct ComponentConfiguration {
     public let device: Kronor.Device?
     /// Whether WebSockets are used for payment status updates.
     public let isWebSocketsEnabled: Bool
+    /// Whether to use `ASWebAuthenticationSession` instead of an embedded `WKWebView`
+    /// for the payment flow. When `true`, the payment gateway page opens in a Safari-powered
+    /// sheet that shares Safari's cookies and user-agent, bypassing Cloudflare challenges
+    /// that block `WKWebView`. Defaults to `false`.
+    public let prefersAuthenticationSession: Bool
 
     /// Creates a new component configuration.
     /// - Parameters:
@@ -28,17 +33,20 @@ public struct ComponentConfiguration {
     ///   - returnURL: The URL to redirect back to after the payment flow.
     ///   - device: Optional device information. Defaults to `nil`.
     ///   - isWebSocketsEnabled: Whether WebSockets are used for payment status updates. Defaults to `true`.
+    ///   - prefersAuthenticationSession: Whether to use `ASWebAuthenticationSession` instead of `WKWebView`. Defaults to `false`.
     public init(
         env: Kronor.Environment,
         sessionToken: String,
         returnURL: URL,
         device: Kronor.Device? = nil,
-        isWebSocketsEnabled: Bool = true
+        isWebSocketsEnabled: Bool = true,
+        prefersAuthenticationSession: Bool = false
     ) {
         self.env = env
         self.sessionToken = sessionToken
         self.returnURL = returnURL
         self.device = device
         self.isWebSocketsEnabled = isWebSocketsEnabled
+        self.prefersAuthenticationSession = prefersAuthenticationSession
     }
 }

--- a/KronorComponents/Common/EmbeddedPaymentView.swift
+++ b/KronorComponents/Common/EmbeddedPaymentView.swift
@@ -13,6 +13,7 @@ struct EmbeddedPaymentView<Content: View>: View {
     @ObservedObject private var webViewModel = WebViewModel()
     @State private var keepWaitingOpen = false
     @State private var showAuthSession = false
+    @State private var authSessionIntentionallyClosed = false
     private var waitingView: Content
     
     init (viewModel: EmbeddedPaymentViewModel, waitingView: Content) {
@@ -45,11 +46,12 @@ struct EmbeddedPaymentView<Content: View>: View {
                     .onReceive(embeddedPayViewModel.$embeddedSiteURL) { embeddedSiteURL in
                         showAuthSession = embeddedSiteURL != nil
                     }
-                    .fullScreenCover(isPresented: $showAuthSession) {
-                        if let url = self.embeddedPayViewModel.embeddedSiteURL {
+                    .fullScreenCover(isPresented: $showAuthSession, onDismiss: onAuthSessionDismissed) {
+                        if let url = self.embeddedPayViewModel.embeddedSiteURL,
+                           let scheme = embeddedPayViewModel.returnURL.scheme {
                             AuthSessionViewRepresentable(
                                 url: url,
-                                callbackScheme: embeddedPayViewModel.returnURL.scheme ?? "",
+                                callbackScheme: scheme,
                                 onComplete: dismissAuthSession,
                                 onCancel: cancelNow
                             )
@@ -115,7 +117,14 @@ struct EmbeddedPaymentView<Content: View>: View {
     }
     
     private func dismissAuthSession() {
+        authSessionIntentionallyClosed = true
         showAuthSession = false
+    }
+
+    private func onAuthSessionDismissed() {
+        defer { authSessionIntentionallyClosed = false }
+        guard !authSessionIntentionallyClosed else { return }
+        dismissSheet()
     }
 
     private func dismissSheet() {

--- a/KronorComponents/Common/EmbeddedPaymentView.swift
+++ b/KronorComponents/Common/EmbeddedPaymentView.swift
@@ -6,11 +6,13 @@
 //
 
 import SwiftUI
+import AuthenticationServices
 
 struct EmbeddedPaymentView<Content: View>: View {
     @ObservedObject private var embeddedPayViewModel: EmbeddedPaymentViewModel
     @ObservedObject private var webViewModel = WebViewModel()
     @State private var keepWaitingOpen = false
+    @State private var showAuthSession = false
     private var waitingView: Content
     
     init (viewModel: EmbeddedPaymentViewModel, waitingView: Content) {
@@ -37,24 +39,42 @@ struct EmbeddedPaymentView<Content: View>: View {
     private func innerBody() -> some View {
         switch embeddedPayViewModel.state {
         case .initializing, .creatingPaymentRequest, .waitingForPaymentRequest, .paymentRequestInitialized, .waitingForPayment:
-            self.waitingView
-                .transition(.slide)
-                .onReceive(embeddedPayViewModel.$embeddedSiteURL.combineLatest(webViewModel.$link)) { (embeddedSiteURL, link) in
-                        if let _ = embeddedSiteURL {
-                            keepWaitingOpen = (link != embeddedPayViewModel.returnURL)
-                        } else {
-                            keepWaitingOpen = false
-                        }
-                }
-                .sheet(isPresented: $keepWaitingOpen, onDismiss: dismissSheet) {
-                    if let url = self.embeddedPayViewModel.embeddedSiteURL {
-                        EmbeddedSiteView(
-                            webViewModel: self.webViewModel,
-                            url: url,
-                            onCancel: cancelNow
-                        )
+            if embeddedPayViewModel.prefersAuthenticationSession {
+                self.waitingView
+                    .transition(.slide)
+                    .onReceive(embeddedPayViewModel.$embeddedSiteURL) { embeddedSiteURL in
+                        showAuthSession = embeddedSiteURL != nil
                     }
-                }
+                    .fullScreenCover(isPresented: $showAuthSession) {
+                        if let url = self.embeddedPayViewModel.embeddedSiteURL {
+                            AuthSessionViewRepresentable(
+                                url: url,
+                                callbackScheme: embeddedPayViewModel.returnURL.scheme ?? "",
+                                onComplete: dismissAuthSession,
+                                onCancel: cancelNow
+                            )
+                        }
+                    }
+            } else {
+                self.waitingView
+                    .transition(.slide)
+                    .onReceive(embeddedPayViewModel.$embeddedSiteURL.combineLatest(webViewModel.$link)) { (embeddedSiteURL, link) in
+                            if let _ = embeddedSiteURL {
+                                keepWaitingOpen = (link != embeddedPayViewModel.returnURL)
+                            } else {
+                                keepWaitingOpen = false
+                            }
+                    }
+                    .sheet(isPresented: $keepWaitingOpen, onDismiss: dismissSheet) {
+                        if let url = self.embeddedPayViewModel.embeddedSiteURL {
+                            EmbeddedSiteView(
+                                webViewModel: self.webViewModel,
+                                url: url,
+                                onCancel: cancelNow
+                            )
+                        }
+                    }
+            }
         case .paymentRejected:
             PaymentRejectedView(viewModel: self.embeddedPayViewModel)
         case .paymentCompleted:
@@ -94,6 +114,10 @@ struct EmbeddedPaymentView<Content: View>: View {
         }
     }
     
+    private func dismissAuthSession() {
+        showAuthSession = false
+    }
+
     private func dismissSheet() {
         Task {
             if self.embeddedPayViewModel.state != .paymentCompleted && self.embeddedPayViewModel.state != .paymentRejected {

--- a/KronorComponents/Common/EmbeddedPaymentViewModel.swift
+++ b/KronorComponents/Common/EmbeddedPaymentViewModel.swift
@@ -64,6 +64,7 @@ class EmbeddedPaymentViewModel: ObservableObject {
     internal let sessionURL: URL
     internal let returnURL: URL
     internal let intermediateRedirectURL: URL
+    internal let prefersAuthenticationSession: Bool
     
     @Published var state: EmbeddedPaymentStatechart.State
     @Published var embeddedSiteURL: URL?
@@ -95,7 +96,8 @@ class EmbeddedPaymentViewModel: ObservableObject {
 
         self.sessionURL = components.url!
         self.returnURL = configuration.returnURL
-        
+        self.prefersAuthenticationSession = configuration.prefersAuthenticationSession
+
         components.path = "/" + paymentMethod.getName().lowercased() + "-redirect"
         self.intermediateRedirectURL = components.url!
     }


### PR DESCRIPTION
Implementing an optional ASWebAuthenticationSession, and enabling consumers to use it in the EuroBonus case, where it is required for the verification step to pass a Cloudflare challenge due to a user-agent mismatch in the WKWebView.

[Apple's documentation on ASWebAuthenticationSession](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession)