### PR TITLE
Ensuring a second enqueued connection doesn't fail

### DIFF
--- a/KronorComponents/Common/KronorPaymentNetworking.swift
+++ b/KronorComponents/Common/KronorPaymentNetworking.swift
@@ -102,6 +102,8 @@ extension KronorPaymentNetworking {
 
         return try await withCheckedThrowingContinuation { continuation in
             connection.stateUpdateHandler = { state in
+                guard connection.stateUpdateHandler != nil else { return }
+
                 switch state {
                 case .ready:
                     connection.stateUpdateHandler = nil


### PR DESCRIPTION
On a bad connection, it would likely trigger both a `waiting` and `failed` continuation resume. The first state would go through, while the second would crash because a continuation can't be resumed twice.