### PR TITLE
Pass merchantReturnUrl in Trustly/BankTransfer payment mutation

### DIFF
--- a/KronorComponents/Trustly/KronorTrustlyPaymentNetworking.swift
+++ b/KronorComponents/Trustly/KronorTrustlyPaymentNetworking.swift
@@ -9,6 +9,7 @@ final class KronorTrustlyPaymentNetworking: KronorPaymentNetworking, TrustlyPaym
         let input = KronorApi.BankTransferPaymentInput(
             flow: "mcom",
             idempotencyKey: UUID().uuidString,
+            merchantReturnUrl: .some(returnURL.absoluteString),
             returnUrl: returnURL.absoluteString
         )
 


### PR DESCRIPTION
## Summary

- The `newBankTransferPayment` GraphQL mutation was not setting the `merchantReturnUrl` field in `BankTransferPaymentInput`, so Trustly payments couldn't redirect back to the merchant's URL after completion.
- Fixed by populating `merchantReturnUrl: .some(returnURL.absoluteString)` in `KronorTrustlyPaymentNetworking.createPaymentRequest`, mirroring the Android SDK's behaviour ([reference](https://github.com/kronor-io/kronor-android/blob/064ad0e9824a157a61f55a848bdd23013e0b528f/kronor_bank_transfer/src/main/java/io/kronor/component/bank_transfer/BankTransferViewModel.kt#L105-L115)).
- `BankTransferComponent` is fixed transitively — it reuses `KronorTrustlyPaymentNetworking` directly.