### PR TITLE
Fixes Trustly's swiftui freezes in the host app

### DIFF
--- a/KronorComponents/BankTransfer/BankTransferComponent.swift
+++ b/KronorComponents/BankTransfer/BankTransferComponent.swift
@@ -10,7 +10,7 @@ import Kronor
 
 /// A payment component that handles bank transfer payments.
 public struct BankTransferComponent: View {
-    let viewModel: TrustlyPaymentViewModel
+    @StateObject private var viewModel: TrustlyPaymentViewModel
 
     /// Creates a new bank transfer payment component.
     /// - Parameters:
@@ -20,24 +20,21 @@ public struct BankTransferComponent: View {
         configuration: ComponentConfiguration,
         paymentResultHandler: @escaping PaymentResultHandler
     ) {
-        let machine = EmbeddedPaymentStatechart.makeStateMachine()
-        let networking = KronorTrustlyPaymentNetworking(configuration: configuration)
-        let viewModel = TrustlyPaymentViewModel(
-            stateMachine: machine,
-            networking: networking,
-            returnURL: configuration.returnURL,
-            paymentResultHandler: paymentResultHandler
+        _viewModel = StateObject(
+            wrappedValue: TrustlyPaymentViewModel(
+                stateMachine: EmbeddedPaymentStatechart.makeStateMachine(),
+                networking: KronorTrustlyPaymentNetworking(configuration: configuration),
+                returnURL: configuration.returnURL,
+                paymentResultHandler: paymentResultHandler
+            )
         )
-
-        self.viewModel = viewModel
-
-        Task {
-            await viewModel.transition(.initialize)
-        }
     }
 
     public var body: some View {
         TrustlyPaymentView(viewModel: self.viewModel)
+            .task {
+                await viewModel.transition(.initialize)
+            }
     }
 }
 

--- a/KronorComponents/Trustly/TrustlyComponent.swift
+++ b/KronorComponents/Trustly/TrustlyComponent.swift
@@ -3,7 +3,7 @@ import Kronor
 
 /// A payment component that handles Trustly payments.
 public struct TrustlyComponent: View {
-    let viewModel: TrustlyPaymentViewModel
+    @StateObject private var viewModel: TrustlyPaymentViewModel
 
     /// Creates a new Trustly payment component.
     /// - Parameters:
@@ -13,24 +13,21 @@ public struct TrustlyComponent: View {
         configuration: ComponentConfiguration,
         paymentResultHandler: @escaping PaymentResultHandler
     ) {
-        let machine = EmbeddedPaymentStatechart.makeStateMachine()
-        let networking = KronorTrustlyPaymentNetworking(configuration: configuration)
-        let viewModel = TrustlyPaymentViewModel(
-            stateMachine: machine,
-            networking: networking,
-            returnURL: configuration.returnURL,
-            paymentResultHandler: paymentResultHandler
+        _viewModel = StateObject(
+            wrappedValue: TrustlyPaymentViewModel(
+                stateMachine: EmbeddedPaymentStatechart.makeStateMachine(),
+                networking: KronorTrustlyPaymentNetworking(configuration: configuration),
+                returnURL: configuration.returnURL,
+                paymentResultHandler: paymentResultHandler
+            )
         )
-        
-        self.viewModel = viewModel
-        
-        Task {
-            await viewModel.transition(.initialize)
-        }
     }
 
     public var body: some View {
         TrustlyPaymentView(viewModel: self.viewModel)
+            .task {
+                await viewModel.transition(.initialize)
+            }
     }
 }
 

--- a/KronorComponents/Trustly/TrustlyWebView.swift
+++ b/KronorComponents/Trustly/TrustlyWebView.swift
@@ -69,4 +69,20 @@ struct TrustlyWebView: UIViewRepresentable {
     func updateUIView(_ uiView: UIViewType, context: Context) {
         uiView.subviews.compactMap { $0 as? WKWebView }.first?.frame = preferredFrame
     }
+
+    /// Breaks the WKWebView ↔ WKScriptMessageHandler retain cycle inside `TrustlyIosSdk`.
+    ///
+    /// `TrustlyWKScriptHandler` holds a strong reference to its `WKWebView`, while the
+    /// `WKWebView`'s `userContentController` holds a strong reference to the handler.
+    /// The Trustly SDK never tears the cycle down, so each `TrustlyWKWebView` we create
+    /// leaks one `WKWebView` + one `TrustlyWKScriptHandler`. Removing the handler from
+    /// the user content controller here drops one edge of the cycle so both can deinit.
+    static func dismantleUIView(_ uiView: UIView, coordinator: ()) {
+        uiView.subviews
+            .compactMap { $0 as? WKWebView }
+            .first?
+            .configuration
+            .userContentController
+            .removeAllScriptMessageHandlers()
+    }
 }


### PR DESCRIPTION
The state machine leaks instances in these components, but with these changes, those zombies are removed, and my host app no longer freezes when I create and cancel one or more Trustly payments.
I don't know if this issue also exists for the other components' state machines, as I have only verified the problem and solution in these specific components.

The issue in Trustly's library causes memory leaks of the following elements in the host app
- TrustlyWKScriptHandler
- WKWebView
- WKUserContentController
- WKWebViewConfiguration
- WebContent

With the proposed fix, these will no longer be leaked, but the host app will complain in xcode's console, where it will periodically attempt to close the now-closed webviews.
I suspect the real fix would need to go into Trustly's library, but the proposed patch is acceptable to me.