### PR TITLE
Fix view model lifecycle in payment components

### DIFF
--- a/KronorComponents/Common/EmbeddedPaymentViewModel.swift
+++ b/KronorComponents/Common/EmbeddedPaymentViewModel.swift
@@ -260,6 +260,7 @@ class EmbeddedPaymentViewModel: ObservableObject {
     }
 
     private func subscribeToPaymentStatusMatcher(matcher: @escaping (KronorApi.PaymentStatusSubscription.Data.PaymentRequest) -> Bool) async {
+        self.subscription?.cancel()
         self.subscription = await networking.subscribeToPaymentStatus { [weak self] result, _ in
             switch result {
                 

--- a/KronorComponents/CreditCard/CreditCardComponent.swift
+++ b/KronorComponents/CreditCard/CreditCardComponent.swift
@@ -10,7 +10,7 @@ import Kronor
 
 /// A payment component that handles credit card payments.
 public struct CreditCardComponent: View {
-    let viewModel: EmbeddedPaymentViewModel
+    @StateObject private var viewModel: EmbeddedPaymentViewModel
 
     /// Creates a new credit card payment component.
     /// - Parameters:
@@ -20,26 +20,23 @@ public struct CreditCardComponent: View {
         configuration: ComponentConfiguration,
         paymentResultHandler: @escaping PaymentResultHandler
     ) {
-        let machine = EmbeddedPaymentStatechart.makeStateMachine()
-        let networking = KronorEmbeddedPaymentNetworking(configuration: configuration)
-        let viewModel = EmbeddedPaymentViewModel(
-            configuration: configuration,
-            stateMachine: machine,
-            networking: networking,
-            paymentMethod: .creditCard,
-            paymentResultHandler: paymentResultHandler
+        _viewModel = StateObject(
+            wrappedValue: EmbeddedPaymentViewModel(
+                configuration: configuration,
+                stateMachine: EmbeddedPaymentStatechart.makeStateMachine(),
+                networking: KronorEmbeddedPaymentNetworking(configuration: configuration),
+                paymentMethod: .creditCard,
+                paymentResultHandler: paymentResultHandler
+            )
         )
-
-        self.viewModel = viewModel
-
-        Task {
-            await viewModel.transition(.initialize)
-        }
     }
 
     public var body: some View {
         WrapperView(header: CreditCardHeaderView(viewModel: self.viewModel)) {
             EmbeddedPaymentView(viewModel: self.viewModel, waitingView: CreditCardWaitingView())
+        }
+        .task {
+            await viewModel.transition(.initialize)
         }
     }
 }

--- a/KronorComponents/Fallback/FallbackComponent.swift
+++ b/KronorComponents/Fallback/FallbackComponent.swift
@@ -10,7 +10,7 @@ import Kronor
 
 /// A generic payment component that handles payment methods without a dedicated component.
 public struct FallbackComponent: View {
-    let viewModel: EmbeddedPaymentViewModel
+    @StateObject private var viewModel: EmbeddedPaymentViewModel
 
     /// Creates a new fallback payment component.
     /// - Parameters:
@@ -22,21 +22,15 @@ public struct FallbackComponent: View {
         paymentMethodName: String,
         paymentResultHandler: @escaping PaymentResultHandler
     ) {
-        let machine = EmbeddedPaymentStatechart.makeStateMachine()
-        let networking = KronorEmbeddedPaymentNetworking(configuration: configuration)
-        let viewModel = EmbeddedPaymentViewModel(
-            configuration: configuration,
-            stateMachine: machine,
-            networking: networking,
-            paymentMethod: .fallback(name: paymentMethodName),
-            paymentResultHandler: paymentResultHandler
+        _viewModel = StateObject(
+            wrappedValue: EmbeddedPaymentViewModel(
+                configuration: configuration,
+                stateMachine: EmbeddedPaymentStatechart.makeStateMachine(),
+                networking: KronorEmbeddedPaymentNetworking(configuration: configuration),
+                paymentMethod: .fallback(name: paymentMethodName),
+                paymentResultHandler: paymentResultHandler
+            )
         )
-
-        self.viewModel = viewModel
-
-        Task {
-            await viewModel.initialize()
-        }
     }
 
     public var body: some View {
@@ -45,6 +39,9 @@ public struct FallbackComponent: View {
                 viewModel: self.viewModel,
                 waitingView: FallbackWaitingView()
             )
+        }
+        .task {
+            await viewModel.initialize()
         }
     }
 }

--- a/KronorComponents/MobilePay/MobilePayComponent.swift
+++ b/KronorComponents/MobilePay/MobilePayComponent.swift
@@ -10,7 +10,7 @@ import Kronor
 
 /// A payment component that handles MobilePay payments.
 public struct MobilePayComponent: View {
-    let viewModel: EmbeddedPaymentViewModel
+    @StateObject private var viewModel: EmbeddedPaymentViewModel
 
     /// Creates a new MobilePay payment component.
     /// - Parameters:
@@ -20,21 +20,15 @@ public struct MobilePayComponent: View {
         configuration: ComponentConfiguration,
         paymentResultHandler: @escaping PaymentResultHandler
     ) {
-        let machine = EmbeddedPaymentStatechart.makeStateMachine()
-        let networking = KronorEmbeddedPaymentNetworking(configuration: configuration)
-        let viewModel = EmbeddedPaymentViewModel(
-            configuration: configuration,
-            stateMachine: machine,
-            networking: networking,
-            paymentMethod: .mobilePay,
-            paymentResultHandler: paymentResultHandler
+        _viewModel = StateObject(
+            wrappedValue: EmbeddedPaymentViewModel(
+                configuration: configuration,
+                stateMachine: EmbeddedPaymentStatechart.makeStateMachine(),
+                networking: KronorEmbeddedPaymentNetworking(configuration: configuration),
+                paymentMethod: .mobilePay,
+                paymentResultHandler: paymentResultHandler
+            )
         )
-
-        self.viewModel = viewModel
-
-        Task {
-            await viewModel.transition(.initialize)
-        }
     }
 
     public var body: some View {
@@ -43,6 +37,9 @@ public struct MobilePayComponent: View {
                 viewModel: self.viewModel,
                 waitingView: MobilePayWaitingView()
             )
+        }
+        .task {
+            await viewModel.transition(.initialize)
         }
     }
 }

--- a/KronorComponents/P24/P24Component.swift
+++ b/KronorComponents/P24/P24Component.swift
@@ -10,7 +10,7 @@ import Kronor
 
 /// A payment component that handles Przelewy24 (P24) payments.
 public struct P24Component: View {
-    let viewModel: EmbeddedPaymentViewModel
+    @StateObject private var viewModel: EmbeddedPaymentViewModel
 
     /// Creates a new P24 payment component.
     /// - Parameters:
@@ -20,21 +20,15 @@ public struct P24Component: View {
         configuration: ComponentConfiguration,
         paymentResultHandler: @escaping PaymentResultHandler
     ) {
-        let machine = EmbeddedPaymentStatechart.makeStateMachine()
-        let networking = KronorEmbeddedPaymentNetworking(configuration: configuration)
-        let viewModel = EmbeddedPaymentViewModel(
-            configuration: configuration,
-            stateMachine: machine,
-            networking: networking,
-            paymentMethod: .p24,
-            paymentResultHandler: paymentResultHandler
+        _viewModel = StateObject(
+            wrappedValue: EmbeddedPaymentViewModel(
+                configuration: configuration,
+                stateMachine: EmbeddedPaymentStatechart.makeStateMachine(),
+                networking: KronorEmbeddedPaymentNetworking(configuration: configuration),
+                paymentMethod: .p24,
+                paymentResultHandler: paymentResultHandler
+            )
         )
-        
-        self.viewModel = viewModel
-        
-        Task {
-            await viewModel.initialize()
-        }
     }
 
     public var body: some View {
@@ -43,6 +37,9 @@ public struct P24Component: View {
                 viewModel: self.viewModel,
                 waitingView: FallbackWaitingView()
             )
+        }
+        .task {
+            await viewModel.initialize()
         }
     }
 }

--- a/KronorComponents/PayPal/PayPalComponent.swift
+++ b/KronorComponents/PayPal/PayPalComponent.swift
@@ -10,7 +10,7 @@ import Kronor
 
 /// A payment component that handles PayPal payments.
 public struct PayPalComponent: View {
-    let viewModel: EmbeddedPaymentViewModel
+    @StateObject private var viewModel: EmbeddedPaymentViewModel
 
     /// Creates a new PayPal payment component.
     /// - Parameters:
@@ -20,22 +20,15 @@ public struct PayPalComponent: View {
         configuration: ComponentConfiguration,
         paymentResultHandler: @escaping PaymentResultHandler
     ) {
-        let machine = EmbeddedPaymentStatechart.makeStateMachine()
-        let networking = KronorEmbeddedPaymentNetworking(configuration: configuration)
-
-        let viewModel = EmbeddedPaymentViewModel(
-            configuration: configuration,
-            stateMachine: machine,
-            networking: networking,
-            paymentMethod: .payPal,
-            paymentResultHandler: paymentResultHandler
+        _viewModel = StateObject(
+            wrappedValue: EmbeddedPaymentViewModel(
+                configuration: configuration,
+                stateMachine: EmbeddedPaymentStatechart.makeStateMachine(),
+                networking: KronorEmbeddedPaymentNetworking(configuration: configuration),
+                paymentMethod: .payPal,
+                paymentResultHandler: paymentResultHandler
+            )
         )
-
-        self.viewModel = viewModel
-
-        Task {
-            await viewModel.transition(.initialize)
-        }
     }
 
     public var body: some View {
@@ -44,6 +37,9 @@ public struct PayPalComponent: View {
                 viewModel: self.viewModel,
                 waitingView: PayPalWaitingView()
             )
+        }
+        .task {
+            await viewModel.transition(.initialize)
         }
     }
 }

--- a/KronorComponents/PointsPay/PointsPayComponent.swift
+++ b/KronorComponents/PointsPay/PointsPayComponent.swift
@@ -13,7 +13,7 @@ import Kronor
 /// Uses `ASWebAuthenticationSession` instead of an embedded `WKWebView`
 /// to bypass Cloudflare challenges that block `WKWebView`.
 public struct PointsPayComponent: View {
-    let viewModel: EmbeddedPaymentViewModel
+    @StateObject private var viewModel: EmbeddedPaymentViewModel
 
     /// Creates a new PointsPay payment component.
     /// - Parameters:
@@ -23,22 +23,16 @@ public struct PointsPayComponent: View {
         configuration: ComponentConfiguration,
         paymentResultHandler: @escaping PaymentResultHandler
     ) {
-        let machine = EmbeddedPaymentStatechart.makeStateMachine()
-        let networking = KronorEmbeddedPaymentNetworking(configuration: configuration)
-        let viewModel = EmbeddedPaymentViewModel(
-            configuration: configuration,
-            stateMachine: machine,
-            networking: networking,
-            paymentMethod: .pointsPay,
-            paymentResultHandler: paymentResultHandler,
-            prefersAuthenticationSession: true
+        _viewModel = StateObject(
+            wrappedValue: EmbeddedPaymentViewModel(
+                configuration: configuration,
+                stateMachine: EmbeddedPaymentStatechart.makeStateMachine(),
+                networking: KronorEmbeddedPaymentNetworking(configuration: configuration),
+                paymentMethod: .pointsPay,
+                paymentResultHandler: paymentResultHandler,
+                prefersAuthenticationSession: true
+            )
         )
-
-        self.viewModel = viewModel
-
-        Task {
-            await viewModel.initialize()
-        }
     }
 
     public var body: some View {
@@ -47,6 +41,9 @@ public struct PointsPayComponent: View {
                 viewModel: self.viewModel,
                 waitingView: FallbackWaitingView()
             )
+        }
+        .task {
+            await viewModel.initialize()
         }
     }
 }

--- a/KronorComponents/Swish/SwishComponent.swift
+++ b/KronorComponents/Swish/SwishComponent.swift
@@ -10,7 +10,7 @@ import Kronor
 
 /// A payment component that handles Swish payments.
 public struct SwishComponent: View {
-    let viewModel: SwishPaymentViewModel
+    @StateObject private var viewModel: SwishPaymentViewModel
 
     /// Creates a new Swish payment component.
     /// - Parameters:
@@ -20,15 +20,14 @@ public struct SwishComponent: View {
         configuration: ComponentConfiguration,
         paymentResultHandler: @escaping PaymentResultHandler
     ) {
-        let machine = SwishStatechart.makeStateMachine()
-        let networking = KronorSwishPaymentNetworking(configuration: configuration)
-        self.viewModel = SwishPaymentViewModel(
-            stateMachine: machine,
-            networking: networking,
-            returnURL: configuration.returnURL,
-            paymentResultHandler: paymentResultHandler
+        _viewModel = StateObject(
+            wrappedValue: SwishPaymentViewModel(
+                stateMachine: SwishStatechart.makeStateMachine(),
+                networking: KronorSwishPaymentNetworking(configuration: configuration),
+                returnURL: configuration.returnURL,
+                paymentResultHandler: paymentResultHandler
+            )
         )
-
     }
 
     public var body: some View {

--- a/KronorComponents/Swish/SwishPaymentViewModel.swift
+++ b/KronorComponents/Swish/SwishPaymentViewModel.swift
@@ -195,6 +195,7 @@ class SwishPaymentViewModel: ObservableObject {
     }
     
     private func subscribeToPaymentStatus(waitToken: String) async {
+        self.subscription?.cancel()
         self.subscription = await networking.subscribeToPaymentStatus { [weak self] result, apiError in
             switch result {
                 

--- a/KronorComponents/Trustly/TrustlyPaymentViewModel.swift
+++ b/KronorComponents/Trustly/TrustlyPaymentViewModel.swift
@@ -131,6 +131,7 @@ class TrustlyPaymentViewModel: ObservableObject {
     }
     
     private func subscribeToPaymentStatus(waitToken: String) async {
+        self.subscription?.cancel()
         self.subscription = await networking.subscribeToPaymentStatus { [weak self] result, apiError in
             switch result {
                 

--- a/KronorComponents/Vipps/VippsComponent.swift
+++ b/KronorComponents/Vipps/VippsComponent.swift
@@ -10,7 +10,7 @@ import Kronor
 
 /// A payment component that handles Vipps payments.
 public struct VippsComponent: View {
-    let viewModel: EmbeddedPaymentViewModel
+    @StateObject private var viewModel: EmbeddedPaymentViewModel
 
     /// Creates a new Vipps payment component.
     /// - Parameters:
@@ -20,21 +20,15 @@ public struct VippsComponent: View {
         configuration: ComponentConfiguration,
         paymentResultHandler: @escaping PaymentResultHandler
     ) {
-        let machine = EmbeddedPaymentStatechart.makeStateMachine()
-        let networking = KronorEmbeddedPaymentNetworking(configuration: configuration)
-        let viewModel = EmbeddedPaymentViewModel(
-            configuration: configuration,
-            stateMachine: machine,
-            networking: networking,
-            paymentMethod: .vipps,
-            paymentResultHandler: paymentResultHandler
+        _viewModel = StateObject(
+            wrappedValue: EmbeddedPaymentViewModel(
+                configuration: configuration,
+                stateMachine: EmbeddedPaymentStatechart.makeStateMachine(),
+                networking: KronorEmbeddedPaymentNetworking(configuration: configuration),
+                paymentMethod: .vipps,
+                paymentResultHandler: paymentResultHandler
+            )
         )
-
-        self.viewModel = viewModel
-
-        Task {
-            await viewModel.transition(.initialize)
-        }
     }
 
     public var body: some View {
@@ -43,6 +37,9 @@ public struct VippsComponent: View {
                 viewModel: self.viewModel,
                 waitingView: VippsWaitingView()
             )
+        }
+        .task {
+            await viewModel.transition(.initialize)
         }
     }
 }


### PR DESCRIPTION
Moved to using StateObject for all view models in payment components.

Without @StateObject, SwiftUI can recreate the view model on any parent re-render, losing the in-flight payment state. This is currently masked by the shared ApolloStore cache.