### PR TITLE
Call refreshPaymentStatus when redirected back from the external payment app

### DIFF
--- a/KronorApi/Client.swift
+++ b/KronorApi/Client.swift
@@ -123,6 +123,12 @@ public extension KronorApi {
                 $0.newBankTransferPayment.paymentId
             }
     }
+
+    static func refreshPaymentStatus(client: ApolloClient) async -> Result<Bool, KronorError> {
+        await sendMutation(client: client, mutation: KronorApi.RefreshPaymentStatusMutation()) {
+            $0.refreshPaymentStatus.result
+        }
+    }
 }
 
 

--- a/KronorApi/Operations/Mutations/RefreshPaymentStatusMutation.graphql.swift
+++ b/KronorApi/Operations/Mutations/RefreshPaymentStatusMutation.graphql.swift
@@ -1,0 +1,60 @@
+// @generated
+// This file was automatically generated and should not be edited.
+
+@_exported import ApolloAPI
+@_spi(Execution) @_spi(Unsafe) import ApolloAPI
+
+public extension KronorApi {
+  nonisolated struct RefreshPaymentStatusMutation: GraphQLMutation {
+    public static let operationName: String = "RefreshPaymentStatus"
+    public static let operationDocument: ApolloAPI.OperationDocument = .init(
+      definition: .init(
+        #"mutation RefreshPaymentStatus { refreshPaymentStatus { __typename result } }"#
+      ))
+
+    public init() {}
+
+    nonisolated public struct Data: KronorApi.SelectionSet {
+      @_spi(Unsafe) public let __data: DataDict
+      @_spi(Unsafe) public init(_dataDict: DataDict) { __data = _dataDict }
+
+      @_spi(Execution) public static var __parentType: any ApolloAPI.ParentType { KronorApi.Objects.Mutation_root }
+      @_spi(Execution) public static var __selections: [ApolloAPI.Selection] { [
+        .field("refreshPaymentStatus", RefreshPaymentStatus.self),
+      ] }
+      @_spi(Execution) public static var __fulfilledFragments: [any ApolloAPI.SelectionSet.Type] { [
+        RefreshPaymentStatusMutation.Data.self
+      ] }
+
+      /// Trigger an immediate poll of the payment provider's status. Fired when
+      /// the customer is redirected back to Kronor from the provider's app
+      /// so the backend re-checks status immediately instead of waiting on
+      /// the provider's webhook (which can arrive late) or the next scheduled
+      /// poll.
+      public var refreshPaymentStatus: RefreshPaymentStatus { __data["refreshPaymentStatus"] }
+
+      /// RefreshPaymentStatus
+      ///
+      /// Parent Type: `RefreshPaymentStatusResult`
+      nonisolated public struct RefreshPaymentStatus: KronorApi.SelectionSet {
+        @_spi(Unsafe) public let __data: DataDict
+        @_spi(Unsafe) public init(_dataDict: DataDict) { __data = _dataDict }
+
+        @_spi(Execution) public static var __parentType: any ApolloAPI.ParentType { KronorApi.Objects.RefreshPaymentStatusResult }
+        @_spi(Execution) public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
+          .field("result", Bool.self),
+        ] }
+        @_spi(Execution) public static var __fulfilledFragments: [any ApolloAPI.SelectionSet.Type] { [
+          RefreshPaymentStatusMutation.Data.RefreshPaymentStatus.self
+        ] }
+
+        /// True when the immediate status poll was accepted. The actual status
+        /// change lands asynchronously once the poll completes; the frontend
+        /// continues its normal status subscription/polling.
+        public var result: Bool { __data["result"] }
+      }
+    }
+  }
+
+}

--- a/KronorApi/Schema/Objects/RefreshPaymentStatusResult.graphql.swift
+++ b/KronorApi/Schema/Objects/RefreshPaymentStatusResult.graphql.swift
@@ -1,0 +1,14 @@
+// @generated
+// This file was automatically generated and should not be edited.
+
+import ApolloAPI
+
+public extension KronorApi.Objects {
+  /// The result of triggering an immediate server-side poll of the
+  /// payment provider's status.
+  nonisolated static let RefreshPaymentStatusResult = ApolloAPI.Object(
+    typename: "RefreshPaymentStatusResult",
+    implementedInterfaces: [],
+    keyFields: nil
+  )
+}

--- a/KronorApi/Schema/SchemaMetadata.graphql.swift
+++ b/KronorApi/Schema/SchemaMetadata.graphql.swift
@@ -39,6 +39,7 @@ public extension KronorApi {
       "PayPalPaymentResult": KronorApi.Objects.PayPalPaymentResult,
       "PaymentCancelResult": KronorApi.Objects.PaymentCancelResult,
       "PaymentRequest": KronorApi.Objects.PaymentRequest,
+      "RefreshPaymentStatusResult": KronorApi.Objects.RefreshPaymentStatusResult,
       "SwishDetails": KronorApi.Objects.SwishDetails,
       "SwishPaymentResult": KronorApi.Objects.SwishPaymentResult,
       "VippsDetails": KronorApi.Objects.VippsDetails,

--- a/KronorComponents/Common/AuthSessionView.swift
+++ b/KronorComponents/Common/AuthSessionView.swift
@@ -14,13 +14,13 @@ struct AuthSessionViewRepresentable: UIViewControllerRepresentable {
 
     private let url: URL
     private let callbackScheme: String
-    private let onComplete: () -> Void
+    private let onComplete: (URL?) -> Void
     private let onCancel: () -> Void
 
     init(
         url: URL,
         callbackScheme: String,
-        onComplete: @escaping () -> Void,
+        onComplete: @escaping (URL?) -> Void,
         onCancel: @escaping () -> Void
     ) {
         self.url = url
@@ -45,7 +45,7 @@ final class AuthSessionViewController: UIViewController, ASWebAuthenticationPres
 
     private let url: URL
     private let callbackScheme: String
-    private let onComplete: () -> Void
+    private let onComplete: (URL?) -> Void
     private let onCancel: () -> Void
     private var authSession: ASWebAuthenticationSession?
     private var hasStarted = false
@@ -53,7 +53,7 @@ final class AuthSessionViewController: UIViewController, ASWebAuthenticationPres
     init(
         url: URL,
         callbackScheme: String,
-        onComplete: @escaping () -> Void,
+        onComplete: @escaping (URL?) -> Void,
         onCancel: @escaping () -> Void
     ) {
         self.url = url
@@ -79,7 +79,7 @@ final class AuthSessionViewController: UIViewController, ASWebAuthenticationPres
         let session = ASWebAuthenticationSession(
             url: url,
             callbackURLScheme: callbackScheme
-        ) { [onComplete, onCancel] _, error in
+        ) { [onComplete, onCancel] callbackURL, error in
             if let sessionError = error as? ASWebAuthenticationSessionError,
                sessionError.code == .canceledLogin {
                 onCancel()
@@ -91,7 +91,7 @@ final class AuthSessionViewController: UIViewController, ASWebAuthenticationPres
                 return
             }
 
-            onComplete()
+            onComplete(callbackURL)
         }
 
         session.prefersEphemeralWebBrowserSession = false

--- a/KronorComponents/Common/EmbeddedPaymentView.swift
+++ b/KronorComponents/Common/EmbeddedPaymentView.swift
@@ -31,6 +31,8 @@ struct EmbeddedPaymentView<Content: View>: View {
                     }
                     if isCancel ?? false {
                         await self.embeddedPayViewModel.transition(.waitForCancel)
+                    } else {
+                        self.embeddedPayViewModel.refreshPaymentStatus()
                     }
                 }
             })
@@ -119,6 +121,9 @@ struct EmbeddedPaymentView<Content: View>: View {
     private func dismissAuthSession() {
         authSessionIntentionallyClosed = true
         showAuthSession = false
+        // the auth session completed by hitting the return URL scheme, which
+        // means the customer was redirected back from the payment provider
+        embeddedPayViewModel.refreshPaymentStatus()
     }
 
     private func onAuthSessionDismissed() {

--- a/KronorComponents/Common/EmbeddedPaymentView.swift
+++ b/KronorComponents/Common/EmbeddedPaymentView.swift
@@ -24,17 +24,10 @@ struct EmbeddedPaymentView<Content: View>: View {
     var body: some View {
         self.innerBody()
             .onOpenURL(perform: { url in
-                Task {
-                    let components = URLComponents(string: url.absoluteString)
-                    let isCancel = components?.queryItems?.contains{ item in
-                        item.name == "cancel"
-                    }
-                    if isCancel ?? false {
-                        await self.embeddedPayViewModel.transition(.waitForCancel)
-                    } else {
-                        self.embeddedPayViewModel.refreshPaymentStatus()
-                    }
-                }
+                // only react to redirect-returns on the configured return URL,
+                // not to unrelated deep links received while this view is shown
+                guard url.scheme == embeddedPayViewModel.returnURL.scheme else { return }
+                handleRedirectReturn(url: url)
             })
     }
 
@@ -118,12 +111,27 @@ struct EmbeddedPaymentView<Content: View>: View {
         }
     }
     
-    private func dismissAuthSession() {
+    private func dismissAuthSession(callbackURL: URL?) {
         authSessionIntentionallyClosed = true
         showAuthSession = false
         // the auth session completed by hitting the return URL scheme, which
         // means the customer was redirected back from the payment provider
-        embeddedPayViewModel.refreshPaymentStatus()
+        handleRedirectReturn(url: callbackURL)
+    }
+
+    private func handleRedirectReturn(url: URL?) {
+        let components = url.flatMap { URLComponents(url: $0, resolvingAgainstBaseURL: false) }
+        let isCancel = components?.queryItems?.contains { item in
+            item.name == "cancel"
+        } ?? false
+
+        if isCancel {
+            Task {
+                await self.embeddedPayViewModel.transition(.waitForCancel)
+            }
+        } else {
+            self.embeddedPayViewModel.refreshPaymentStatus()
+        }
     }
 
     private func onAuthSessionDismissed() {

--- a/KronorComponents/Common/EmbeddedPaymentViewModel.swift
+++ b/KronorComponents/Common/EmbeddedPaymentViewModel.swift
@@ -130,6 +130,21 @@ class EmbeddedPaymentViewModel: ObservableObject {
         await subscribeToPaymentStatusMatcher(matcher: {_ in true })
     }
 
+    /// Asks the backend to poll the payment provider immediately instead of
+    /// waiting on the provider's webhook (which can arrive late) or the next
+    /// scheduled poll. Fired when the customer is redirected back to the app
+    /// from the external payment app. Failures are only logged: the regular
+    /// payment status subscription remains the source of truth.
+    func refreshPaymentStatus() {
+        Task { [weak self] in
+            guard let self else { return }
+            Self.logger.debug("refreshing payment status after redirect")
+            if case .failure(let error) = await self.networking.refreshPaymentStatus() {
+                Self.logger.warning("could not refresh payment status: \(String(describing: error))")
+            }
+        }
+    }
+
     private func handleSideEffect(sideEffect: EmbeddedPaymentStatechart.SideEffect) async {
         switch sideEffect {
             

--- a/KronorComponents/Common/EmbeddedPaymentViewModel.swift
+++ b/KronorComponents/Common/EmbeddedPaymentViewModel.swift
@@ -139,7 +139,12 @@ class EmbeddedPaymentViewModel: ObservableObject {
         Task { [weak self] in
             guard let self else { return }
             Self.logger.debug("refreshing payment status after redirect")
-            if case .failure(let error) = await self.networking.refreshPaymentStatus() {
+            switch await self.networking.refreshPaymentStatus() {
+            case .success(let accepted):
+                if !accepted {
+                    Self.logger.warning("payment status refresh was not accepted by the backend")
+                }
+            case .failure(let error):
                 Self.logger.warning("could not refresh payment status: \(String(describing: error))")
             }
         }

--- a/KronorComponents/Common/KronorPaymentNetworking.swift
+++ b/KronorComponents/Common/KronorPaymentNetworking.swift
@@ -85,6 +85,10 @@ class KronorPaymentNetworking: PaymentNetworking {
         )
         return .success(())
     }
+
+    func refreshPaymentStatus() async -> Result<Bool, KronorApi.KronorError> {
+        await KronorApi.refreshPaymentStatus(client: client)
+    }
 }
 
 // MARK: - Helpers

--- a/KronorComponents/Common/PaymentNetworking.swift
+++ b/KronorComponents/Common/PaymentNetworking.swift
@@ -14,4 +14,6 @@ protocol PaymentNetworking {
     ) async -> Task<Void, Never>
 
     func cancelSessionPayments() async -> Result<(), Never>
+
+    func refreshPaymentStatus() async -> Result<Bool, KronorApi.KronorError>
 }

--- a/graphql/RefreshPaymentStatus.graphql
+++ b/graphql/RefreshPaymentStatus.graphql
@@ -1,0 +1,11 @@
+# Hasura presets merchantId and paymentReference on RefreshPaymentStatusInput from
+# the session JWT, so the whole input is stripped from the payment-gateway role's
+# schema and the mutation is called with no arguments. Fired once when the customer
+# is redirected back from the provider's app, to make the backend poll the provider
+# for status immediately instead of waiting on a late webhook or the next scheduled
+# poll.
+mutation RefreshPaymentStatus {
+  refreshPaymentStatus {
+    result
+  }
+}

--- a/schema.graphqls
+++ b/schema.graphqls
@@ -2242,6 +2242,19 @@ type PointspayPaymentResult {
 }
 
 """
+The result of triggering an immediate server-side poll of the
+payment provider's status.
+"""
+type RefreshPaymentStatusResult {
+  """
+  True when the immediate status poll was accepted. The actual status
+  change lands asynchronously once the poll completes; the frontend
+  continues its normal status subscription/polling.
+  """
+  result: Boolean!
+}
+
+"""
 Boolean expression to compare columns of type "spoken_lang". All fields are combined with logical 'AND'.
 """
 input SpokenLangComparisonExp {
@@ -3041,6 +3054,15 @@ type mutation_root {
   Create a new payment request to receive money via Vipps, available only in Norway.
   """
   newVippsPayment(pay: VippsPaymentInput!): VippsPaymentResult!
+
+  """
+  Trigger an immediate poll of the payment provider's status. Fired when
+  the customer is redirected back to Kronor from the provider's app
+  so the backend re-checks status immediately instead of waiting on
+  the provider's webhook (which can arrive late) or the next scheduled
+  poll.
+  """
+  refreshPaymentStatus: RefreshPaymentStatusResult!
 
   """Update the frontend flow state of a bank transfer"""
   updateBankTransferFlow(flow: BankTransferFlowInput!): BankTransferFlowResult!


### PR DESCRIPTION
## What

Calls the new `refreshPaymentStatus` mutation (added in kronor-io/kronor#5493) when the customer is redirected back to the app from the external payment app, so the backend polls the provider for status immediately instead of waiting on a late webhook or the next scheduled poll (60–90s out).

## How

The mutation fires from the two redirect-return chokepoints in `EmbeddedPaymentView`, covering MobilePay, Vipps, PayPal, credit card and the fallback methods (bank transfer, P24, PointsPay):

- **`.onOpenURL`** — the external app deep-links back into the merchant app via the return URL (the existing `cancel` query-param case still transitions to `.waitForCancel` instead)
- **auth session completion** — `ASWebAuthenticationSession` caught the return URL scheme

Plumbing:

- `schema.graphqls`: added `refreshPaymentStatus` + `RefreshPaymentStatusResult` from the payment-gateway role schema. Hasura presets `merchantId`/`paymentReference` on the input from the session JWT, so the client calls the mutation with no arguments (same as the web frontend).
- `graphql/RefreshPaymentStatus.graphql` + regenerated `KronorApi` code (apollo-ios-cli 2.1.1).
- `KronorApi.refreshPaymentStatus(client:)` helper following the existing `sendMutation` pattern.
- `PaymentNetworking.refreshPaymentStatus()` implemented once in `KronorPaymentNetworking`.
- `EmbeddedPaymentViewModel.refreshPaymentStatus()` is fire-and-forget with logging — the regular payment status subscription remains the source of truth, mirroring the backend contract ("the actual status change lands asynchronously once the poll completes").

## Notes

- **Swish is deliberately excluded**, matching the web frontend's scope in the backend PR (the `payment.poll.now` FSM event was verified from `PROCESSING_REDIRECTED_*` states). If we want it for Swish mcom too, we should first confirm the backend statechart accepts the event from Swish's processing states.
- Trustly/PointsPay no-op the poll server-side, so firing for fallback methods is harmless.
- Heads-up: the `apollo-ios-cli` committed at the repo root is still 1.21.0 and regenerates everything in the pre-2.x format — I used the 2.1.1 CLI bundled in the apollo-ios package checkout instead. Worth replacing the committed binary in a follow-up.

## Verification

`xcodebuild -scheme KronorComponents -destination 'generic/platform=iOS Simulator' build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)