### PR TITLE
Adopt Swift 6 strict concurrency

### DIFF
--- a/Kronor/Kronor/Device.swift
+++ b/Kronor/Kronor/Device.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import FingerprintJS
+@preconcurrency import FingerprintJS
 import SwiftUI
 
 let  fingerprinter = FingerprinterFactory.getInstance()
@@ -148,7 +148,7 @@ extension UIDevice {
         uname(&systemInfo)
         let modelCode = withUnsafePointer(to: &systemInfo.machine) {
             $0.withMemoryRebound(to: CChar.self, capacity: 1) {
-                ptr in String.init(validatingUTF8: ptr)
+                ptr in String(validatingCString: ptr)
             }
         }
     

--- a/Kronor/Kronor/Environment.swift
+++ b/Kronor/Kronor/Environment.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public extension Kronor {
-    struct Environment {
+    struct Environment: Sendable {
         public let name: String
         public let apiURL: URL
         public let websocketURL: URL

--- a/KronorComponents/Common/ComponentConfiguration.swift
+++ b/KronorComponents/Common/ComponentConfiguration.swift
@@ -9,7 +9,7 @@ import Foundation
 import Kronor
 
 /// Shared configuration for all payment components.
-public struct ComponentConfiguration {
+public struct ComponentConfiguration: Sendable {
     /// The Kronor environment to use.
     public let env: Kronor.Environment
     /// The session token obtained from the backend via the `newPaymentSession` query.

--- a/KronorComponents/Common/EmbeddedPaymentStatechart.swift
+++ b/KronorComponents/Common/EmbeddedPaymentStatechart.swift
@@ -11,7 +11,7 @@ import KronorApi
 
 final class EmbeddedPaymentStatechart : StateMachineBuilder {
     
-    enum State : Equatable  {
+    enum State: Equatable, Sendable  {
         case initializing
         case creatingPaymentRequest
         case waitingForPaymentRequest
@@ -22,7 +22,7 @@ final class EmbeddedPaymentStatechart : StateMachineBuilder {
         case errored (error: KronorApi.KronorError)
     }
     
-    enum Event : Equatable  {
+    enum Event: Equatable, Sendable  {
         case initialize
         case paymentRequestCreated (waitToken: String)
         case paymentRequestWillBeCreatedElsewhere
@@ -36,7 +36,7 @@ final class EmbeddedPaymentStatechart : StateMachineBuilder {
         case waitForCancel
     }
     
-    enum SideEffect {
+    enum SideEffect: Sendable {
         case createPaymentRequest
         case openEmbeddedSite
         case subscribeToPaymentStatus (waitToken: String)

--- a/KronorComponents/Common/EmbeddedPaymentViewModel.swift
+++ b/KronorComponents/Common/EmbeddedPaymentViewModel.swift
@@ -49,8 +49,8 @@ enum SupportedEmbeddedMethod {
     }
 }
 
-class EmbeddedPaymentViewModel: ObservableObject {
-    
+@MainActor class EmbeddedPaymentViewModel: ObservableObject {
+
     private static let logger = Logger(
         subsystem: Bundle.main.bundleIdentifier!,
         category: String(describing: EmbeddedPaymentViewModel.self)
@@ -115,10 +115,8 @@ class EmbeddedPaymentViewModel: ObservableObject {
                 self.subscription?.cancel()
             }
 
-            await MainActor.run {
-                self.state = result.toState
-                Self.logger.trace("new state: \(String(describing: self.state.hashableIdentifier))")
-            }
+            self.state = result.toState
+            Self.logger.trace("new state: \(String(describing: self.state.hashableIdentifier))")
         }
 
         if let sideEffect = result?.sideEffect {
@@ -201,26 +199,20 @@ class EmbeddedPaymentViewModel: ObservableObject {
         case .notifyPaymentFailure:
             Self.logger.trace("performing notifyPaymentFailure")
             self.subscription?.cancel()
-            await MainActor.run {
-                self.paymentResultHandler(.failure(.declined))
-            }
+            await self.paymentResultHandler(.failure(.declined))
 
 
         case .cancelAndNotifyFailure:
             Self.logger.trace("performing cancelAndNotifyFailure")
             self.subscription?.cancel()
-            await MainActor.run {
-                self.paymentResultHandler(.failure(.cancelled))
-            }
+            await self.paymentResultHandler(.failure(.cancelled))
 
             
         case .notifyPaymentSuccess:
             Self.logger.trace("performing notifyPaymentSuccess")
             self.subscription?.cancel()
             if let paymentId = self.paymenRequest?.resultingPaymentId {
-                await MainActor.run {
-                    self.paymentResultHandler(.success(paymentId))
-                }
+                await self.paymentResultHandler(.success(paymentId))
             } else {
                 Self.logger.error("could not find resultingPaymentId before calling onPaymentSuccess")
             }
@@ -230,10 +222,8 @@ class EmbeddedPaymentViewModel: ObservableObject {
             await subscribeToPaymentStatus(waitToken: waitToken)
      
         case .openEmbeddedSite:
-            await MainActor.run {
-                self.embeddedSiteURL = self.sessionURL
-                Self.logger.info("\(self.sessionURL)")
-            }
+            self.embeddedSiteURL = self.sessionURL
+            Self.logger.info("\(self.sessionURL)")
 
         case .resetState:
             self.subscription?.cancel()
@@ -245,9 +235,7 @@ class EmbeddedPaymentViewModel: ObservableObject {
 
             self.paymenRequest = nil
 
-            await MainActor.run {
-                self.embeddedSiteURL = nil
-            }
+            self.embeddedSiteURL = nil
 
             Task {
                 await self.transition(.initialize)
@@ -277,65 +265,58 @@ class EmbeddedPaymentViewModel: ObservableObject {
 
     private func subscribeToPaymentStatusMatcher(matcher: @escaping (KronorApi.PaymentRequestFields) -> Bool) async {
         self.subscription?.cancel()
-        self.subscription = await networking.subscribeToPaymentStatus { [weak self] result, _ in
-            switch result {
-                
-            case .failure(let error):
-                Task { [weak self] in
-                    await self?.handleError(error: .networkError(error: error))
-                }
-            case .success(let paymentRequests):
-                let request = paymentRequests
-                    .sorted(by: { itemA, itemB in
-                        itemA.createdAt > itemB.createdAt
-                    })
-                    .first(where: { paymentRequest in
-                        matcher(paymentRequest) &&
-                        (paymentRequest.status?.contains { status in
-                            status.status != KronorApi.PaymentStatusEnum.initializing
-                        } ?? false)
-                    })
+        let stream = await networking.subscribeToPaymentStatus()
+        self.subscription = Task { [weak self] in
+            for await (result, _) in stream {
+                guard !Task.isCancelled, let self else { return }
 
-                if let request {
-                    self?.paymenRequest = request
+                switch result {
+                case .failure(let error):
+                    await self.handleError(error: .networkError(error: error))
 
-                    if case .waitingForPaymentRequest = self?.stateMachine.state {
-                        Task { [weak self] in
-                            await self?.transition(.paymentRequestInitialized)
-                        }
-                    }
-                    
-                    if (request.status?.contains {
-                        $0.status == KronorApi.PaymentStatusEnum.paid
-                        || $0.status == KronorApi.PaymentStatusEnum.authorized
-                        || $0.status == KronorApi.PaymentStatusEnum.flowCompleted
-                    }) ?? false {
-                        Task { [weak self] in
-                            await self?.transition(.paymentAuthorized)
-                        }
-                    }
-                    
-                    let wasRejected = request.status?.contains { status in
-                        [KronorApi.PaymentStatusEnum.error, KronorApi.PaymentStatusEnum.declined, KronorApi.PaymentStatusEnum.cancelled].contains {
-                            $0 == status.status.value
-                        }
-                    }
+                case .success(let paymentRequests):
+                    let request = paymentRequests
+                        .sorted(by: { itemA, itemB in
+                            itemA.createdAt > itemB.createdAt
+                        })
+                        .first(where: { paymentRequest in
+                            matcher(paymentRequest) &&
+                            (paymentRequest.status?.contains { status in
+                                status.status != KronorApi.PaymentStatusEnum.initializing
+                            } ?? false)
+                        })
 
-                    if wasRejected ?? false {
-                        Task { [weak self] in
-                            await self?.transition(.paymentRejected)
-                        }
-                    }
+                    if let request {
+                        self.paymenRequest = request
 
-                    if case .initializing = self?.stateMachine.state {
-                        Task { [weak self] in
-                            await self?.transition(.initialize)
+                        if case .waitingForPaymentRequest = self.stateMachine.state {
+                            await self.transition(.paymentRequestInitialized)
                         }
-                    }
 
-                } else {
-                    Task { [weak self] in
-                        await self?.transition(.initialize)
+                        if (request.status?.contains {
+                            $0.status == KronorApi.PaymentStatusEnum.paid
+                            || $0.status == KronorApi.PaymentStatusEnum.authorized
+                            || $0.status == KronorApi.PaymentStatusEnum.flowCompleted
+                        }) ?? false {
+                            await self.transition(.paymentAuthorized)
+                        }
+
+                        let wasRejected = request.status?.contains { status in
+                            [KronorApi.PaymentStatusEnum.error, KronorApi.PaymentStatusEnum.declined, KronorApi.PaymentStatusEnum.cancelled].contains {
+                                $0 == status.status.value
+                            }
+                        }
+
+                        if wasRejected ?? false {
+                            await self.transition(.paymentRejected)
+                        }
+
+                        if case .initializing = self.stateMachine.state {
+                            await self.transition(.initialize)
+                        }
+
+                    } else {
+                        await self.transition(.initialize)
                     }
                 }
             }
@@ -348,15 +329,11 @@ class EmbeddedPaymentViewModel: ObservableObject {
 }
 
 extension EmbeddedPaymentViewModel: RetryableModel {
-    func cancel() {
-        Task {
-            await self.transition(.cancelFlow)
-        }
+    func cancel() async {
+        await self.transition(.cancelFlow)
     }
     
-    func retry() {
-        Task {
-            await self.transition(.retry)
-        }
+    func retry() async {
+        await self.transition(.retry)
     }
 }

--- a/KronorComponents/Common/KronorEmbeddedPaymentNetworking.swift
+++ b/KronorComponents/Common/KronorEmbeddedPaymentNetworking.swift
@@ -10,7 +10,7 @@ import Kronor
 import KronorApi
 import Apollo
 
-final class KronorEmbeddedPaymentNetworking: KronorPaymentNetworking, EmbeddedPaymentNetworking {
+final class KronorEmbeddedPaymentNetworking: KronorPaymentNetworking, EmbeddedPaymentNetworking, @unchecked Sendable {
     func createMobilePayPaymentRequest(
         returnURL: URL
     ) async -> Result<String, KronorApi.KronorError> {

--- a/KronorComponents/Common/KronorPaymentNetworking.swift
+++ b/KronorComponents/Common/KronorPaymentNetworking.swift
@@ -12,7 +12,7 @@ import KronorApi
 import Kronor
 import Network
 
-class KronorPaymentNetworking: PaymentNetworking {
+class KronorPaymentNetworking: PaymentNetworking, @unchecked Sendable {
     private actor State {
         var device: Kronor.Device?
 
@@ -63,17 +63,15 @@ class KronorPaymentNetworking: PaymentNetworking {
         Task { await transport?.pause() }
     }
 
-    func subscribeToPaymentStatus(
-        resultHandler: @escaping (Result<[KronorApi.PaymentRequestFields], Error>, KronorApi.APIError?) -> Void
-    ) async -> Task<Void, Never> {
+    func subscribeToPaymentStatus() async -> AsyncStream<PaymentStatusUpdate> {
         if isWebSocketsEnabled {
             do {
-                return try await websocketPaymentStatusSubscription(resultHandler: resultHandler)
+                return try await websocketPaymentStatusStream()
             } catch {
-                return pollingPaymentStatusSubscription(resultHandler: resultHandler)
+                return pollingPaymentStatusStream()
             }
         } else {
-            return pollingPaymentStatusSubscription(resultHandler: resultHandler)
+            return pollingPaymentStatusStream()
         }
     }
 
@@ -134,56 +132,64 @@ extension KronorPaymentNetworking {
         }
     }
 
-    private func websocketPaymentStatusSubscription(
-        resultHandler: @escaping (Result<[KronorApi.PaymentRequestFields], Error>, KronorApi.APIError?) -> Void
-    ) async throws -> Task<Void, Never> {
+    private func websocketPaymentStatusStream() async throws -> AsyncStream<PaymentStatusUpdate> {
         _ = try await establishWebSocketConnection()
-        let stream = try client.subscribe(subscription: KronorApi.PaymentStatusSubscription())
-        return Task {
-            do {
-                for try await response in stream {
-                    let apiError = response.extractAPIError()
-                    if let data = response.data {
-                        resultHandler(
-                            .success(data.paymentRequests.map { $0.fragments.paymentRequestFields }),
-                            apiError
-                        )
-                    } else {
-                        resultHandler(
-                            .failure(apiError ?? KronorApi.APIError.empty),
-                            apiError
-                        )
+        let subscriptionStream = try client.subscribe(subscription: KronorApi.PaymentStatusSubscription())
+        return AsyncStream { continuation in
+            let task = Task {
+                do {
+                    for try await response in subscriptionStream {
+                        let apiError = response.extractAPIError()
+                        if let data = response.data {
+                            continuation.yield((
+                                result: .success(data.paymentRequests.map { $0.fragments.paymentRequestFields }),
+                                apiError: apiError
+                            ))
+                        } else {
+                            continuation.yield((
+                                result: .failure(apiError ?? .empty),
+                                apiError: apiError
+                            ))
+                        }
                     }
+                    continuation.finish()
+                } catch {
+                    continuation.yield((result: .failure(error), apiError: nil))
+                    continuation.finish()
                 }
-            } catch {
-                resultHandler(.failure(error), nil)
+            }
+            continuation.onTermination = { _ in
+                task.cancel()
             }
         }
     }
 
-    private func pollingPaymentStatusSubscription(
-        resultHandler: @escaping (Result<[KronorApi.PaymentRequestFields], Error>, KronorApi.APIError?) -> Void
-    ) -> Task<Void, Never> {
-        pollingManager.startPolling {
-            do {
-                let response = try await self.client.fetch(
-                    query: KronorApi.PaymentStatusQuery(),
-                    cachePolicy: .networkOnly
-                )
-                let apiError = response.extractAPIError()
-                if let data = response.data {
-                    resultHandler(
-                        .success(data.paymentRequests.map { $0.fragments.paymentRequestFields }),
-                        apiError
+    private func pollingPaymentStatusStream() -> AsyncStream<PaymentStatusUpdate> {
+        AsyncStream { continuation in
+            let task = pollingManager.startPolling { [client] in
+                do {
+                    let response = try await client.fetch(
+                        query: KronorApi.PaymentStatusQuery(),
+                        cachePolicy: .networkOnly
                     )
-                } else {
-                    resultHandler(
-                        .failure(apiError ?? KronorApi.APIError.empty),
-                        apiError
-                    )
+                    let apiError = response.extractAPIError()
+                    if let data = response.data {
+                        continuation.yield((
+                            result: .success(data.paymentRequests.map { $0.fragments.paymentRequestFields }),
+                            apiError: apiError
+                        ))
+                    } else {
+                        continuation.yield((
+                            result: .failure(apiError ?? .empty),
+                            apiError: apiError
+                        ))
+                    }
+                } catch {
+                    continuation.yield((result: .failure(error), apiError: nil))
                 }
-            } catch {
-                resultHandler(.failure(error), nil)
+            }
+            continuation.onTermination = { _ in
+                task.cancel()
             }
         }
     }

--- a/KronorComponents/Common/PaymentNetworking.swift
+++ b/KronorComponents/Common/PaymentNetworking.swift
@@ -1,6 +1,6 @@
 //
 //  PaymentNetworking.swift
-//  
+//
 //
 //  Created by Niclas Heltoft on 17/07/2023.
 //
@@ -8,10 +8,10 @@
 import Foundation
 import KronorApi
 
-protocol PaymentNetworking {
-    func subscribeToPaymentStatus(
-        resultHandler: @escaping (Result<[KronorApi.PaymentRequestFields], Error>, KronorApi.APIError?) -> Void
-    ) async -> Task<Void, Never>
+typealias PaymentStatusUpdate = (result: Result<[KronorApi.PaymentRequestFields], Error>, apiError: KronorApi.APIError?)
+
+protocol PaymentNetworking: Sendable {
+    func subscribeToPaymentStatus() async -> AsyncStream<PaymentStatusUpdate>
 
     func cancelSessionPayments() async -> Result<(), Never>
 

--- a/KronorComponents/Common/PaymentRejectedView.swift
+++ b/KronorComponents/Common/PaymentRejectedView.swift
@@ -37,7 +37,9 @@ struct PaymentRejectedView: View {
                Spacer()
             } else {
                 Button(action: {
-                    viewModel.cancel()
+                    Task {
+                        await viewModel.cancel()
+                    }
                     clickedOnSomething = true
                 }) {
                     Text(
@@ -52,7 +54,9 @@ struct PaymentRejectedView: View {
                     .font(.caption)
                 
                 Button(action: {
-                    viewModel.retry()
+                    Task {
+                        await viewModel.retry()
+                    }
                     clickedOnSomething = true
                 }) {
                     Text(

--- a/KronorComponents/Common/PaymentResultHandler.swift
+++ b/KronorComponents/Common/PaymentResultHandler.swift
@@ -6,4 +6,4 @@
 //
 
 /// A closure that handles the outcome of a payment flow.
-public typealias PaymentResultHandler = (PaymentResult) -> Void
+public typealias PaymentResultHandler = @Sendable (PaymentResult) async -> Void

--- a/KronorComponents/Common/PollingManager.swift
+++ b/KronorComponents/Common/PollingManager.swift
@@ -8,10 +8,10 @@ class PollingManager {
         self.pollingInterval = pollingInterval
     }
 
-    func startPolling(pollingAction: @escaping () async -> Void) -> Task<Void, Never> {
-        let task = Task {
+    func startPolling(pollingAction: sending @escaping () async -> Void) -> Task<Void, Never> {
+        let task = Task { [pollingAction, pollingInterval] in
            while !Task.isCancelled {
-               try? await Task.sleep(nanoseconds: self.pollingInterval * NSEC_PER_SEC)
+               try? await Task.sleep(nanoseconds: pollingInterval * NSEC_PER_SEC)
                if Task.isCancelled {
                    break
                }

--- a/KronorComponents/Common/Preview.swift
+++ b/KronorComponents/Common/Preview.swift
@@ -29,7 +29,7 @@ enum Preview {
         }
     }
 
-    static func makeEmbeddedPaymentViewModel(
+    @MainActor static func makeEmbeddedPaymentViewModel(
         paymentMethod: SupportedEmbeddedMethod,
         state: EmbeddedPaymentStatechart.State? = nil
     ) -> EmbeddedPaymentViewModel {
@@ -49,7 +49,7 @@ enum Preview {
         )
     }
 
-    static func makeSwishPaymentViewModel(
+    @MainActor static func makeSwishPaymentViewModel(
         state: SwishStatechart.State? = nil
     ) -> SwishPaymentViewModel {
         let machine: SwishStatechart.SwishStateMachine

--- a/KronorComponents/Common/RetryableModel.swift
+++ b/KronorComponents/Common/RetryableModel.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-protocol RetryableModel {
-    func cancel()
-    func retry()
+protocol RetryableModel: Sendable {
+    func cancel() async
+    func retry() async
 }

--- a/KronorComponents/Common/SwiftUIWebView.swift
+++ b/KronorComponents/Common/SwiftUIWebView.swift
@@ -48,7 +48,7 @@ struct SwiftUIWebView: UIViewRepresentable {
 
         func webView(_ webView: WKWebView,
                      decidePolicyFor navigationAction: WKNavigationAction,
-                     decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+                     decisionHandler: @escaping @MainActor (WKNavigationActionPolicy) -> Void) {
 
             // if the url is not http(s) schema, then the UIApplication open the url
             if let url = navigationAction.request.url,

--- a/KronorComponents/Swish/KronorSwishPaymentNetworking.swift
+++ b/KronorComponents/Swish/KronorSwishPaymentNetworking.swift
@@ -9,7 +9,7 @@ import Foundation
 import Kronor
 import KronorApi
 
-final class KronorSwishPaymentNetworking: KronorPaymentNetworking, SwishPaymentNetworking {
+final class KronorSwishPaymentNetworking: KronorPaymentNetworking, SwishPaymentNetworking, @unchecked Sendable {
     func createMcomPaymentRequest(
         returnURL: URL
     ) async -> Result<String, KronorApi.KronorError> {

--- a/KronorComponents/Swish/SwishPaymentViewModel.swift
+++ b/KronorComponents/Swish/SwishPaymentViewModel.swift
@@ -14,8 +14,8 @@ import os
 import UIKit
 #endif
 
-class SwishPaymentViewModel: ObservableObject {
-    
+@MainActor class SwishPaymentViewModel: ObservableObject {
+
     private static let logger = Logger(
             subsystem: Bundle.main.bundleIdentifier!,
             category: String(describing: SwishPaymentViewModel.self)
@@ -73,10 +73,8 @@ class SwishPaymentViewModel: ObservableObject {
                 self.subscription?.cancel()
             }
 
-            await MainActor.run {
-                self.state = result.toState
-                Self.logger.trace("new state: \(String(describing: self.state.hashableIdentifier))")
-            }
+            self.state = result.toState
+            Self.logger.trace("new state: \(String(describing: self.state.hashableIdentifier))")
         }
 
         if let sideEffect = result?.sideEffect {
@@ -124,25 +122,19 @@ class SwishPaymentViewModel: ObservableObject {
         case .notifyPaymentFailure:
             Self.logger.trace("performing notifyPaymentFailure")
             self.subscription?.cancel()
-            await MainActor.run {
-                self.paymentResultHandler(.failure(.declined))
-            }
+            await self.paymentResultHandler(.failure(.declined))
         
         case .cancelFlow:
             Self.logger.trace("performing cancelFlow")
             self.subscription?.cancel()
-            await MainActor.run {
-                self.paymentResultHandler(.failure(.cancelled))
-            }
+            await self.paymentResultHandler(.failure(.cancelled))
 
             
         case .notifyPaymentSuccess:
             Self.logger.trace("performing notifyPaymentSuccess")
             self.subscription?.cancel()
             if let paymentId = self.paymenRequest?.resultingPaymentId {
-                await MainActor.run {
-                    self.paymentResultHandler(.success(paymentId))
-                }
+                await self.paymentResultHandler(.success(paymentId))
             } else {
                 Self.logger.error("could not find resultingPaymentId before calling onPaymentSuccess")
             }
@@ -150,24 +142,15 @@ class SwishPaymentViewModel: ObservableObject {
             
         case .openSwishApp:
 #if canImport(UIKit)
-            if self.swishAppInstalled {
-                await MainActor.run {
-                    if let url = self.swishURL {
-                        Self.logger.debug("attempting to open \(url)")
-                        UIApplication.shared.open(url) { [weak self] success in
-                            if success {
-                                Task {
-                                    await self?.transition(.swishAppOpened)
-                                }
-                            } else {
-                                Self.logger.trace("could not open swish app")
-                                self?.swishAppInstalled = false
-                                Task {
-                                    await self?.transition(.retry)
-                                }
-                            }
-                        }
-                    }
+            if self.swishAppInstalled, let url = self.swishURL {
+                Self.logger.debug("attempting to open \(url)")
+                let success = await UIApplication.shared.open(url)
+                if success {
+                    await transition(.swishAppOpened)
+                } else {
+                    Self.logger.trace("could not open swish app")
+                    self.swishAppInstalled = false
+                    await transition(.retry)
                 }
             }
 #endif
@@ -195,66 +178,58 @@ class SwishPaymentViewModel: ObservableObject {
     
     private func subscribeToPaymentStatus(waitToken: String) async {
         self.subscription?.cancel()
-        self.subscription = await networking.subscribeToPaymentStatus { [weak self] result, apiError in
-            switch result {
-                
-            case .failure(let error):
-                Task { [weak self] in
-                    await self?.handleError(error: .networkError(error: error))
-                }
-            case .success(let paymentRequests):
-                let request = paymentRequests
-                    .first(where: { paymentRequest in
-                        paymentRequest.waitToken == waitToken &&
-                        
-                        (paymentRequest.status?.contains { status in
-                            status.status != KronorApi.PaymentStatusEnum.initializing
-                        } ?? false)
-                    })
+        let stream = await networking.subscribeToPaymentStatus()
+        self.subscription = Task { [weak self] in
+            for await (result, apiError) in stream {
+                guard !Task.isCancelled, let self else { return }
 
-                if let request {
-                    self?.paymenRequest = request
-                    
-                    if case .waitingForPaymentRequest(_) = self?.stateMachine.state {
-                        Task { [weak self] in
-                            await self?.transition(.paymentRequestInitialized)
+                switch result {
+                case .failure(let error):
+                    await self.handleError(error: .networkError(error: error))
+
+                case .success(let paymentRequests):
+                    let request = paymentRequests
+                        .first(where: { paymentRequest in
+                            paymentRequest.waitToken == waitToken &&
+
+                            (paymentRequest.status?.contains { status in
+                                status.status != KronorApi.PaymentStatusEnum.initializing
+                            } ?? false)
+                        })
+
+                    if let request {
+                        self.paymenRequest = request
+
+                        if case .waitingForPaymentRequest(_) = self.stateMachine.state {
+                            await self.transition(.paymentRequestInitialized)
                         }
-                    }
-                    
-                    if (request.status?.contains { $0.status == KronorApi.PaymentStatusEnum.paid || $0.status == KronorApi.PaymentStatusEnum.authorized }) ?? false {
-                        Task { [weak self] in
-                            await self?.transition(.paymentAuthorized)
+
+                        if (request.status?.contains { $0.status == KronorApi.PaymentStatusEnum.paid || $0.status == KronorApi.PaymentStatusEnum.authorized }) ?? false {
+                            await self.transition(.paymentAuthorized)
                         }
-                    }
-                    
-                    let wasRejected = request.status?.contains { status in
-                        [KronorApi.PaymentStatusEnum.error, KronorApi.PaymentStatusEnum.declined, KronorApi.PaymentStatusEnum.cancelled].contains {
-                            $0 == status.status.value
+
+                        let wasRejected = request.status?.contains { status in
+                            [KronorApi.PaymentStatusEnum.error, KronorApi.PaymentStatusEnum.declined, KronorApi.PaymentStatusEnum.cancelled].contains {
+                                $0 == status.status.value
+                            }
+                        }
+
+                        if wasRejected ?? false {
+                            await self.transition(.paymentRejected)
                         }
                     }
 
-                    if wasRejected ?? false {
-                        Task { [weak self] in
-                            await self?.transition(.paymentRejected)
-                        }
-                    }
-                }
-                
-                if let error = apiError {
-                    Task { [weak self] in
-                        await self?.handleError(
-                            error: .usageError(
-                                error: error
-                            )
+                    if let error = apiError {
+                        await self.handleError(
+                            error: .usageError(error: error)
                         )
                     }
                 }
-
             }
         }
     }
     
-    deinit {
+    isolated deinit {
         switch self.state {
         case .waitingForPayment, .paymentRequestInitialized(_), .creatingPaymentRequest(_), .waitingForPaymentRequest(_):
             Task { [networking] in
@@ -269,15 +244,11 @@ class SwishPaymentViewModel: ObservableObject {
 }
 
 extension SwishPaymentViewModel: RetryableModel {
-    func cancel() {
-        Task {
-            await self.transition(.cancelFlow)
-        }
+    func cancel() async {
+        await self.transition(.cancelFlow)
     }
     
-    func retry() {
-        Task {
-            await self.transition(.retry)
-        }
+    func retry() async {
+        await self.transition(.retry)
     }
 }

--- a/KronorComponents/Swish/SwishStatechart.swift
+++ b/KronorComponents/Swish/SwishStatechart.swift
@@ -11,7 +11,7 @@ import KronorApi
 
 final class SwishStatechart : StateMachineBuilder {
     
-    enum State : Equatable  {
+    enum State: Equatable, Sendable  {
         case promptingMethod
         case insertingPhoneNumber
         case creatingPaymentRequest (selected: SelectedMethod)
@@ -23,7 +23,7 @@ final class SwishStatechart : StateMachineBuilder {
         case errored (error: KronorApi.KronorError)
     }
     
-    enum Event : Equatable  {
+    enum Event: Equatable, Sendable  {
         case useSwishApp
         case usePhoneNumber
         case phoneNumberInserted (number: String)
@@ -38,7 +38,7 @@ final class SwishStatechart : StateMachineBuilder {
         case swishAppOpened
     }
     
-    enum SideEffect {
+    enum SideEffect: Sendable {
         case createEcomPaymentRequest (phoneNumber: String)
         case createMcomPaymentRequest
         case openSwishApp
@@ -49,7 +49,7 @@ final class SwishStatechart : StateMachineBuilder {
         case cancelFlow
     }
     
-    enum SelectedMethod : Equatable {
+    enum SelectedMethod: Equatable, Sendable {
         case swishApp
         case qrCode
         case phoneNumber

--- a/KronorComponents/Trustly/KronorTrustlyPaymentNetworking.swift
+++ b/KronorComponents/Trustly/KronorTrustlyPaymentNetworking.swift
@@ -2,7 +2,7 @@ import Foundation
 import Kronor
 import KronorApi
 
-final class KronorTrustlyPaymentNetworking: KronorPaymentNetworking, TrustlyPaymentNetworking {
+final class KronorTrustlyPaymentNetworking: KronorPaymentNetworking, TrustlyPaymentNetworking, @unchecked Sendable {
     func createPaymentRequest(
         returnURL: URL
     ) async -> Result<String, KronorApi.KronorError> {

--- a/KronorComponents/Trustly/TrustlyPaymentViewModel.swift
+++ b/KronorComponents/Trustly/TrustlyPaymentViewModel.swift
@@ -3,8 +3,8 @@ import Kronor
 import KronorApi
 import os
 
-class TrustlyPaymentViewModel: ObservableObject {
-    
+@MainActor class TrustlyPaymentViewModel: ObservableObject {
+
     private static let logger = Logger(
             subsystem: Bundle.main.bundleIdentifier!,
             category: String(describing: TrustlyPaymentViewModel.self)
@@ -52,10 +52,8 @@ class TrustlyPaymentViewModel: ObservableObject {
                 self.subscription?.cancel()
             }
 
-            await MainActor.run {
-                self.state = result.toState
-                Self.logger.trace("new state: \(String(describing: self.state.hashableIdentifier))")
-            }
+            self.state = result.toState
+            Self.logger.trace("new state: \(String(describing: self.state.hashableIdentifier))")
         }
 
         if let sideEffect = result?.sideEffect {
@@ -69,17 +67,13 @@ class TrustlyPaymentViewModel: ObservableObject {
         case .notifyPaymentFailure:
             Self.logger.trace("performing notifyPaymentFailure")
             self.subscription?.cancel()
-            await MainActor.run {
-                self.paymentResultHandler(.failure(.declined))
-            }
+            await self.paymentResultHandler(.failure(.declined))
         
         case .notifyPaymentSuccess:
             Self.logger.trace("performing notifyPaymentSuccess")
             self.subscription?.cancel()
             if let paymentId = self.paymenRequest?.resultingPaymentId {
-                await MainActor.run {
-                    self.paymentResultHandler(.success(paymentId))
-                }
+                await self.paymentResultHandler(.success(paymentId))
             } else {
                 Self.logger.error("could not find resultingPaymentId before calling onPaymentSuccess")
             }
@@ -111,17 +105,13 @@ class TrustlyPaymentViewModel: ObservableObject {
             }
         case .openEmbeddedSite:
             if let url = self.payURL {
-                await MainActor.run {
-                    self.trustlyCheckoutURL = url
-                    Self.logger.info("\(url)")
-                }
+                self.trustlyCheckoutURL = url
+                Self.logger.info("\(url)")
             }
         case .cancelAndNotifyFailure, .cancelAfterDeadline:
             Self.logger.trace("performing cancelAndNotifyFailure")
             self.subscription?.cancel()
-            await MainActor.run {
-                self.paymentResultHandler(.failure(.cancelled))
-            }
+            await self.paymentResultHandler(.failure(.cancelled))
         }
     }
     
@@ -131,72 +121,64 @@ class TrustlyPaymentViewModel: ObservableObject {
     
     private func subscribeToPaymentStatus(waitToken: String) async {
         self.subscription?.cancel()
-        self.subscription = await networking.subscribeToPaymentStatus { [weak self] result, apiError in
-            switch result {
-                
-            case .failure(let error):
-                Task { [weak self] in
-                    await self?.handleError(error: .networkError(error: error))
-                }
-            case .success(let paymentRequests):
-                let request = paymentRequests
-                    .sorted(by: { itemA, itemB in
-                        itemA.createdAt > itemB.createdAt
-                    })
-                    .first(where: { paymentRequest in
-                        paymentRequest.waitToken == waitToken &&
-                        
-                        (paymentRequest.status?.contains { status in
-                            status.status != KronorApi.PaymentStatusEnum.initializing
-                        } ?? false)
-                    })
+        let stream = await networking.subscribeToPaymentStatus()
+        self.subscription = Task { [weak self] in
+            for await (result, apiError) in stream {
+                guard !Task.isCancelled, let self else { return }
 
-                if let request {
-                    self?.paymenRequest = request
-                    
-                    if case .waitingForPaymentRequest = self?.stateMachine.state {
-                        Task { [weak self] in
-                            await self?.transition(.paymentRequestInitialized)
+                switch result {
+                case .failure(let error):
+                    await self.handleError(error: .networkError(error: error))
+
+                case .success(let paymentRequests):
+                    let request = paymentRequests
+                        .sorted(by: { itemA, itemB in
+                            itemA.createdAt > itemB.createdAt
+                        })
+                        .first(where: { paymentRequest in
+                            paymentRequest.waitToken == waitToken &&
+
+                            (paymentRequest.status?.contains { status in
+                                status.status != KronorApi.PaymentStatusEnum.initializing
+                            } ?? false)
+                        })
+
+                    if let request {
+                        self.paymenRequest = request
+
+                        if case .waitingForPaymentRequest = self.stateMachine.state {
+                            await self.transition(.paymentRequestInitialized)
                         }
-                    }
-                    
-                    if (request.status?.contains {
-                        $0.status == KronorApi.PaymentStatusEnum.paid
-                        || $0.status == KronorApi.PaymentStatusEnum.flowCompleted
-                        || $0.status == KronorApi.PaymentStatusEnum.authorized }) ?? false {
-                        Task { [weak self] in
-                            await self?.transition(.paymentAuthorized)
+
+                        if (request.status?.contains {
+                            $0.status == KronorApi.PaymentStatusEnum.paid
+                            || $0.status == KronorApi.PaymentStatusEnum.flowCompleted
+                            || $0.status == KronorApi.PaymentStatusEnum.authorized }) ?? false {
+                            await self.transition(.paymentAuthorized)
                         }
-                    }
-                    
-                    let wasRejected = request.status?.contains { status in
-                        [KronorApi.PaymentStatusEnum.error, KronorApi.PaymentStatusEnum.declined, KronorApi.PaymentStatusEnum.cancelled].contains {
-                            $0 == status.status.value
+
+                        let wasRejected = request.status?.contains { status in
+                            [KronorApi.PaymentStatusEnum.error, KronorApi.PaymentStatusEnum.declined, KronorApi.PaymentStatusEnum.cancelled].contains {
+                                $0 == status.status.value
+                            }
+                        }
+
+                        if wasRejected ?? false {
+                            await self.transition(.paymentRejected)
                         }
                     }
 
-                    if wasRejected ?? false {
-                        Task { [weak self] in
-                            await self?.transition(.paymentRejected)
-                        }
-                    }
-                }
-                
-                if let error = apiError {
-                    Task { [weak self] in
-                        await self?.handleError(
-                            error: .usageError(
-                                error: error
-                            )
+                    if let error = apiError {
+                        await self.handleError(
+                            error: .usageError(error: error)
                         )
                     }
                 }
-
             }
         }
     }
     
-    deinit {
+    isolated deinit {
         switch self.state {
         case .waitingForPayment, .waitingForPaymentRequest:
             Task { [networking] in
@@ -211,15 +193,11 @@ class TrustlyPaymentViewModel: ObservableObject {
 }
 
 extension TrustlyPaymentViewModel: RetryableModel {
-    func cancel() {
-        Task {
-            await self.transition(.cancelFlow)
-        }
+    func cancel() async {
+        await self.transition(.cancelFlow)
     }
     
-    func retry() {
-        Task {
-            await self.transition(.retry)
-        }
+    func retry() async {
+        await self.transition(.retry)
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 6.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
Enables Swift 6 language mode and resolves all concurrency warnings and errors across the codebase.

Networking classes are marked @unchecked Sendable - this is safe, but should be revisited later. A move to using actors together with composition would be preferable.